### PR TITLE
Add Docker functionality and GitHub Actions CI

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . --tag "arma3server:$(date +%s)"
+      run: docker build . --tag "alter-ego:$(date +%s)"
 
   docker-compose:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,7 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Copy .env file
-      run: cp .env.example .env
     - name: Build the Docker image
       run: docker-compose build

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,20 @@
+name: Docker Image CI
+
+on: [pull_request]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --tag "arma3server:$(date +%s)"
+
+  docker-compose:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Copy .env file
+      run: cp .env.example .env
+    - name: Build the Docker image
+      run: docker-compose build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish Image
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout repo
+        uses: actions/checkout@v4
+      - 
+        name: Build image tag
+        run: echo "IMAGE_TAG=$(git log -1 --pretty=%h)" >> $GITHUB_ENV 
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3 
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/flufflesamy/alter-ego:${{ env.IMAGE_TAG }}
+            ghcr.io/flufflesamy/alter-ego:latest
+          file: ./Dockerfile
+          build-args: |
+              IMAGE_TAG=${{ env.IMAGE_TAG }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   publish:
@@ -30,8 +30,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/flufflesamy/alter-ego:${{ env.IMAGE_TAG }}
-            ghcr.io/flufflesamy/alter-ego:latest
+            ghcr.io/${{ secrets.GH_USERNAME }}/alter-ego:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ secrets.GH_USERNAME }}/alter-ego:latest
           file: ./Dockerfile
           build-args: |
               IMAGE_TAG=${{ env.IMAGE_TAG }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Bot files
-credentials*.json
 settings-*.json
 *.bat
 Old_Commands/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /home/node/app
 COPY package*.json ./
 
 RUN chown -R node:node /home/node/app
+RUN apt-get install -y tzdata
 
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:lts-slim
+ENV NODE_ENV production
+
+WORKDIR /home/node/app
+
+COPY package*.json ./
+
+RUN chown -R node:node /home/node/app
+
+USER node
+
+RUN npm install
+
+COPY --chown=node:node . .
+
+CMD [ "node", "bot.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /home/node/app
 COPY package*.json ./
 
 RUN chown -R node:node /home/node/app
-RUN apt-get install -y tzdata
 
 USER node
 

--- a/credentials.json
+++ b/credentials.json
@@ -1,0 +1,17 @@
+{
+    "discord": {
+        "token": "(CONFIDENTIAL)"
+    },
+    "google": {
+        "type": "service_account",
+        "project_id": "(CONFIDENTIAL)",
+        "private_key_id": "(CONFIDENTIAL)",
+        "private_key": "(CONFIDENTIAL)",
+        "client_email": "(CONFIDENTIAL)",
+        "client_id": "(CONFIDENTIAL)",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "(CONFIDENTIAL)"
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,5 @@ services:
     volumes:
       # Bind mounts for configuration files
       - ./credentials.json:/home/node/app/credentials.json
-      - ./game.json:/home/node/app/game.json
       - ./settings.json:/home/node/app/settings.json
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: alterego
     volumes:
       # Bind mounts for configuration files
-      - ./credentials.json:/app/Alter-Ego/credentials.json
-      - ./game.json:/app/Alter-Ego/game.json
-      - ./settings.json:/app/Alter-Ego/settings.json
+      - ./credentials.json:/app/credentials.json
+      - ./game.json:/app/game.json
+      - ./settings.json:/app/settings.json
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   alterego:
-    image: ghcr.io/flufflesamy/alter-ego:latest
+    image: ghcr.io/molsnoo/alter-ego:latest
     container_name: alterego
     environment:
       TZ: "America/Los_Angeles"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+
+services:
+  alterego:
+    image: ghcr.io/flufflesamy/alter-ego:latest
+    container_name: alterego
+    volumes:
+      # Bind mounts for configuration files
+      - ./credentials.json:/app/Alter-Ego/credentials.json
+      - ./game.json:/app/Alter-Ego/game.json
+      - ./settings.json:/app/Alter-Ego/settings.json
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   alterego:
     image: ghcr.io/flufflesamy/alter-ego:latest
     container_name: alterego
+    environment:
+      - TZ="America/Los_Angeles"
     volumes:
       # Bind mounts for configuration files
       - ./credentials.json:/home/node/app/credentials.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: alterego
     volumes:
       # Bind mounts for configuration files
-      - ./credentials.json:/app/credentials.json
-      - ./game.json:/app/game.json
-      - ./settings.json:/app/settings.json
+      - ./credentials.json:/home/node/app/credentials.json
+      - ./game.json:/home/node/app/game.json
+      - ./settings.json:/home/node/app/settings.json
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: ghcr.io/flufflesamy/alter-ego:latest
     container_name: alterego
     environment:
-      - TZ="America/Los_Angeles"
+      TZ: "America/Los_Angeles"
     volumes:
       # Bind mounts for configuration files
       - ./credentials.json:/home/node/app/credentials.json


### PR DESCRIPTION
Added docker image functionality and CI.

Dockerfile builds app on image based on Debian. Respective docker-compose.yml added (although not sure if game.json is persistent and thus need to be binded to the container or not)

CI via Github Actions added. Action builds and publishes image to Github Container Registry. Environment variable GH_USERNAME must be set to repo owner's username for it to work.

Finally, dummy credentials.json added. .gitignore line for excluding that file removed.

Documentation in wiki and README will need to be updated to reflect Docker installation. [See this](https://github.com/flufflesamy/AlterEgo-docker) for reference.