### PR TITLE
Implement loader error checking for non-member Players

### DIFF
--- a/Modules/loader.js
+++ b/Modules/loader.js
@@ -1359,7 +1359,7 @@ module.exports.loadPlayers = function (game, doErrorChecking) {
                 if (player.alive) {
                     game.players_alive.push(player);
 
-                    if (player.member !== null) {
+                    if (player.member !== null || player.talent === "NPC") {
                         // Parse statuses and inflict the player with them.
                         const currentPlayer = game.players_alive[game.players_alive.length - 1];
                         for (let j = 0; j < game.statusEffects.length; j++) {


### PR DESCRIPTION
This pull requests implements suppression of the `DiscordAPIError` that blocks `loader.checkPlayer()` from checking for a `null` member, as well as suppression of `Room.leaveChannel()` and `Room.joinChannel()` if `player.member` is `null`. (Or, more specifically, only allows the two aforementioned functions to run if `player.member` is truthy and if `player.talent` is not NPC). There remains a flaw within the message handler where it will constantly spam the console with errors seemingly related to `player.member` being `null`, but that behavior has been left untouched due to the impending message handler rewrite.
-💾 & ♥️