### PR TITLE
Implement Room.exitCollection

### DIFF
--- a/Data/Room.js
+++ b/Data/Room.js
@@ -4,7 +4,7 @@ import GameEntity from './GameEntity.js';
 import Narration from '../Data/Narration.js';
 import Player from './Player.js';
 import { addLogMessage } from '../Modules/messageHandler.js';
-import { TextChannel } from 'discord.js';
+import { Collection, TextChannel } from 'discord.js';
 
 /**
  * @class Room
@@ -51,9 +51,15 @@ export default class Room extends GameEntity {
     iconURL;
     /**
      * The exits of the room.
+     * @deprecated
      * @type {Exit[]}
      */
     exit;
+    /**
+     * A collection of all exits in the room, where they key is the exit's name.
+     * @type {Collection<string, Exit>}
+     */
+    exitCollection;
     /**
      * The default description of the room for when a player enters from the first listed exit or inspects the room.
      * @type {string}
@@ -92,6 +98,7 @@ export default class Room extends GameEntity {
         this.tags = tags;
         this.iconURL = iconURL;
         this.exit = exit;
+        this.exitCollection = new Collection();
         this.description = description;
 
          /** @type {Player[]} */
@@ -118,16 +125,16 @@ export default class Room extends GameEntity {
         else {
             /** @type {Pos} */
             let coordSum = { x: 0, y: 0, z: 0 };
-            for (let i = 0; i < this.exit.length; i++) {
-                coordSum.x += this.exit[i].pos.x;
-                coordSum.y += this.exit[i].pos.y;
-                coordSum.z += this.exit[i].pos.z;
+            for (const [_, exit] of this.exitCollection) {
+                coordSum.x += exit.pos.x;
+                coordSum.y += exit.pos.y;
+                coordSum.z += exit.pos.z;
             }
             /** @type {Pos} */
             let pos = { x: 0, y: 0, z: 0 };
-            pos.x = Math.floor(coordSum.x / this.exit.length);
-            pos.y = Math.floor(coordSum.y / this.exit.length);
-            pos.z = Math.floor(coordSum.z / this.exit.length);
+            pos.x = Math.floor(coordSum.x / this.exitCollection.size);
+            pos.y = Math.floor(coordSum.y / this.exitCollection.size);
+            pos.z = Math.floor(coordSum.z / this.exitCollection.size);
             player.pos = pos;
         }
         if (entranceMessage) new Narration(this.game, player, this, entranceMessage).send();
@@ -207,6 +214,7 @@ export default class Room extends GameEntity {
 
     /**
      * Unlocks an exit in the room.
+     * @deprecated
      * @param {number} index - The exit's index within the room's array of exits.
      */
     unlock(index) {
@@ -219,7 +227,21 @@ export default class Room extends GameEntity {
     }
 
     /**
+     * Unlocks an exit in the room.
+     * @param {string} name - The exit's name key within the room's collection of exits.
+     */
+    unlockExit(name) {
+        let exit = this.exitCollection.get(name)
+        if (this.occupants.length > 0) new Narration(this.game, null, this, `${exit.name} unlocks.`).send();
+
+        // Post log message.
+        const time = new Date().toLocaleTimeString();
+        addLogMessage(this.game, `${time} - ${exit.name} in ${this.channel} was unlocked.`);
+    }
+
+    /**
      * Locks an exit in the room.
+     * @deprecated
      * @param {number} index - The exit's index within the room's array of exits.
      */
     lock(index) {
@@ -229,6 +251,20 @@ export default class Room extends GameEntity {
         // Post log message.
         const time = new Date().toLocaleTimeString();
         addLogMessage(this.game, `${time} - ${this.exit[index].name} in ${this.channel} was locked.`);
+    }
+
+    /**
+     * Locks an exit in the room.
+     * @param {string} name - The exit's name key within the room's collection of exits.
+     */
+    lockExit(name) {
+        let exit = this.exitCollection.get(name)
+        exit.lock();
+        if (this.occupants.length > 0) new Narration(this.game, null, this, `${exit.name} locks.`).send();
+
+        // Post log message.
+        const time = new Date().toLocaleTimeString();
+        addLogMessage(this.game, `${time} - ${exit.name} in ${this.channel} was locked.`);
     }
 
     /** @returns {string} */

--- a/Modules/loader.js
+++ b/Modules/loader.js
@@ -102,7 +102,7 @@ export function loadRooms (game, doErrorChecking) {
                 game
             );
             for (let j = 0; j < exits.length; j++) {
-                room.exitCollection.set(exits[j].name, exits[j]);
+                room.exitCollection.set(Room.generateValidId(exits[j].name), exits[j]);
             }
             if (game.entityFinder.getRoom(room.id))
                 errors.push(new Error(`Couldn't load room on row ${room.row}. Another room with the same ID already exists.`));

--- a/Modules/loader.js
+++ b/Modules/loader.js
@@ -101,6 +101,9 @@ export function loadRooms (game, doErrorChecking) {
                 roomRow + 2,
                 game
             );
+            for (let j = 0; j < exits.length; j++) {
+                room.exitCollection.set(exits[j].name, exits[j]);
+            }
             if (game.entityFinder.getRoom(room.id))
                 errors.push(new Error(`Couldn't load room on row ${room.row}. Another room with the same ID already exists.`));
             else game.roomsCollection.set(room.id, room);
@@ -108,9 +111,9 @@ export function loadRooms (game, doErrorChecking) {
         // Now go through and make the dest for each exit an actual Room object.
         // Also, add any occupants to the room.
         game.roomsCollection.forEach(room => {
-            for (let j = 0; j < room.exit.length; j++) {
-                const dest = game.entityFinder.getRoom(Room.generateValidId(room.exit[j].destDisplayName));
-                if (dest) room.exit[j].dest = dest;
+            for (const [_, exit] of room.exitCollection) {
+                const dest = game.entityFinder.getRoom(Room.generateValidId(exit.destDisplayName));
+                if (dest) exit.dest = dest;
             }
             if (doErrorChecking) {
                 const error = checkRoom(room);
@@ -152,7 +155,7 @@ export function checkRoom (room) {
         return new Error(`Couldn't load room on row ${room.row}. The icon URL must have a .jpg, .jpeg, .png, .gif, .webp, or .avif extension.`);
     /** @type {string[]} */
     let exitNames = [];
-    for (const exit of room.exit) {
+    for (const [_, exit] of room.exitCollection) {
         exitNames.push(exit.name);
         if (exit.name === "" || exit.name === null || exit.name === undefined)
             return new Error(`Couldn't load exit on row ${exit.row}. No exit name was given.`);
@@ -171,9 +174,8 @@ export function checkRoom (room) {
         if (!(exit.dest instanceof Room))
             return new Error(`Couldn't load exit on row ${exit.row}. The destination given is not a room.`);
         let matchingExit = false;
-        for (let j = 0; j < exit.dest.exit.length; j++) {
-            let dest = exit.dest;
-            if (dest.exit[j].link === exit.name) {
+        for (const [_, destExit] of exit.dest.exitCollection) {
+            if (destExit.link === exit.name) {
                 matchingExit = true;
                 break;
             }


### PR DESCRIPTION
With the recent enforcement of unique exit names in any given room, this PR implements exit name-keyed exits in a room at `Room.exitCollection`, and deprecates the existing `Room.exit` property.

I can begin removing reference to the now-deprecated Room.exit property in this branch, or in `feature/optimizations-v2`, whichever is preferred. For now, though, this branch only implements the `Room.exitCollection` property and deprecation of `Room.exit`.
-💾