### PR TITLE
Fix event time parsing

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -28,10 +28,12 @@ import duration from 'dayjs/plugin/duration.js';
 import weekday from 'dayjs/plugin/weekday.js';
 import advancedFormat from 'dayjs/plugin/advancedFormat.js';
 import relativeTime from 'dayjs/plugin/relativeTime.js';
+import customParseFormat from 'dayjs/plugin/customParseFormat.js';
 dayjs.extend(duration);
 dayjs.extend(weekday);
 dayjs.extend(advancedFormat);
 dayjs.extend(relativeTime);
+dayjs.extend(customParseFormat);
 
 const client = new Client({
     partials: [


### PR DESCRIPTION
This PR fixes event start time parsing by extending Day.js with the `CustomParseFormat` plugin.
-🦇