### PR TITLE
Message/Messageable Abstraction

### DIFF
--- a/Classes/EligibleCommand.js
+++ b/Classes/EligibleCommand.js
@@ -1,4 +1,3 @@
-import { Message } from "discord.js";
 import Game from "../Data/Game.js";
 import GameSettings from "./GameSettings.js";
 
@@ -12,7 +11,7 @@ export default class EligibleCommand {
 	 * @constructor
 	 * @param {CommandConfig} config 
 	 * @param {(settings: GameSettings) => string} usage 
-	 * @param {(game: Game, message: Message, command: string, args: string[]) => Promise<void>} execute 
+	 * @param {(game: Game, message: UserMessage, command: string, args: string[]) => Promise<void>} execute 
 	 */
 	constructor(config, usage, execute) {
 		this.config = config;

--- a/Classes/ModeratorCommand.js
+++ b/Classes/ModeratorCommand.js
@@ -1,4 +1,3 @@
-import { Message } from "discord.js";
 import Game from "../Data/Game.js";
 import GameSettings from "./GameSettings.js";
 
@@ -12,7 +11,7 @@ export default class ModeratorCommand {
 	 * @constructor
 	 * @param {CommandConfig} config 
 	 * @param {(settings: GameSettings) => string} usage 
-	 * @param {(game: Game, message: Message, command: string, args: string[]) => Promise<void>} execute 
+	 * @param {(game: Game, message: UserMessage, command: string, args: string[]) => Promise<void>} execute 
 	 */
 	constructor(config, usage, execute) {
 		this.config = config;

--- a/Classes/PlayerCommand.js
+++ b/Classes/PlayerCommand.js
@@ -1,4 +1,3 @@
-import { Message } from "discord.js";
 import Game from "../Data/Game.js";
 import Player from "../Data/Player.js";
 import GameSettings from "./GameSettings.js";
@@ -13,7 +12,7 @@ export default class PlayerCommand {
 	 * @constructor
 	 * @param {CommandConfig} config 
 	 * @param {(settings: GameSettings) => string} usage 
-	 * @param {(game: Game, message: Message, command: string, args: string[], player?: Player) => Promise<void>} execute 
+	 * @param {(game: Game, message: UserMessage, command: string, args: string[], player?: Player) => Promise<void>} execute 
 	 */
 	constructor(config, usage, execute) {
 		this.config = config;

--- a/Commands/addplayer_moderator.js
+++ b/Commands/addplayer_moderator.js
@@ -31,7 +31,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/addplayer_moderator.js
+++ b/Commands/addplayer_moderator.js
@@ -31,7 +31,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/addplayer_moderator.js
+++ b/Commands/addplayer_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import playerdefaults from '../Configs/playerdefaults.json' with { type: 'json' };
 import { appendRowsToSheet } from '../Modules/sheets.js';

--- a/Commands/clean_moderator.js
+++ b/Commands/clean_moderator.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/clean_moderator.js
+++ b/Commands/clean_moderator.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/clean_moderator.js
+++ b/Commands/clean_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { saveGame } from '../Modules/saver.js';
 

--- a/Commands/craft_moderator.js
+++ b/Commands/craft_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/craft_moderator.js
+++ b/Commands/craft_moderator.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/craft_moderator.js
+++ b/Commands/craft_moderator.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/craft_player.js
+++ b/Commands/craft_player.js
@@ -2,7 +2,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/craft_player.js
+++ b/Commands/craft_player.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/craft_player.js
+++ b/Commands/craft_player.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/createroomcategory_moderator.js
+++ b/Commands/createroomcategory_moderator.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/createroomcategory_moderator.js
+++ b/Commands/createroomcategory_moderator.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/createroomcategory_moderator.js
+++ b/Commands/createroomcategory_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { registerRoomCategory, createCategory } from '../Modules/serverManager.js';
 

--- a/Commands/dead_moderator.js
+++ b/Commands/dead_moderator.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/dead_moderator.js
+++ b/Commands/dead_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/dead_moderator.js
+++ b/Commands/dead_moderator.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/delete_moderator.js
+++ b/Commands/delete_moderator.js
@@ -30,7 +30,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/delete_moderator.js
+++ b/Commands/delete_moderator.js
@@ -1,6 +1,6 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { ChannelType, Message } from 'discord.js';
+import { ChannelType } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/delete_moderator.js
+++ b/Commands/delete_moderator.js
@@ -30,7 +30,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/destroy_moderator.js
+++ b/Commands/destroy_moderator.js
@@ -46,7 +46,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/destroy_moderator.js
+++ b/Commands/destroy_moderator.js
@@ -46,7 +46,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/destroy_moderator.js
+++ b/Commands/destroy_moderator.js
@@ -3,7 +3,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { destroyItem, destroyInventoryItem } from '../Modules/itemManager.js';
 

--- a/Commands/dress_moderator.js
+++ b/Commands/dress_moderator.js
@@ -3,7 +3,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/dress_moderator.js
+++ b/Commands/dress_moderator.js
@@ -32,7 +32,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/dress_moderator.js
+++ b/Commands/dress_moderator.js
@@ -32,7 +32,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/dress_player.js
+++ b/Commands/dress_player.js
@@ -33,7 +33,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/dress_player.js
+++ b/Commands/dress_player.js
@@ -33,7 +33,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/dress_player.js
+++ b/Commands/dress_player.js
@@ -5,7 +5,6 @@ import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/drop_moderator.js
+++ b/Commands/drop_moderator.js
@@ -34,7 +34,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/drop_moderator.js
+++ b/Commands/drop_moderator.js
@@ -3,7 +3,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/drop_moderator.js
+++ b/Commands/drop_moderator.js
@@ -34,7 +34,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/drop_player.js
+++ b/Commands/drop_player.js
@@ -36,7 +36,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/drop_player.js
+++ b/Commands/drop_player.js
@@ -36,7 +36,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/drop_player.js
+++ b/Commands/drop_player.js
@@ -5,7 +5,6 @@ import RoomItem from "../Data/RoomItem.js";
 import Player from '../Data/Player.js';
 import Puzzle from "../Data/Puzzle.js";
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/dumplog_moderator.js
+++ b/Commands/dumplog_moderator.js
@@ -36,7 +36,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/dumplog_moderator.js
+++ b/Commands/dumplog_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { format as prettyFormat } from 'pretty-format';
 import zlib from 'zlib';

--- a/Commands/dumplog_moderator.js
+++ b/Commands/dumplog_moderator.js
@@ -36,7 +36,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/editmode_moderator.js
+++ b/Commands/editmode_moderator.js
@@ -31,7 +31,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/editmode_moderator.js
+++ b/Commands/editmode_moderator.js
@@ -31,7 +31,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/editmode_moderator.js
+++ b/Commands/editmode_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { saveGame } from '../Modules/saver.js';
 

--- a/Commands/end_moderator.js
+++ b/Commands/end_moderator.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/end_moderator.js
+++ b/Commands/end_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/end_moderator.js
+++ b/Commands/end_moderator.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/endgame_moderator.js
+++ b/Commands/endgame_moderator.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/endgame_moderator.js
+++ b/Commands/endgame_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/endgame_moderator.js
+++ b/Commands/endgame_moderator.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/equip_moderator.js
+++ b/Commands/equip_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/equip_moderator.js
+++ b/Commands/equip_moderator.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/equip_moderator.js
+++ b/Commands/equip_moderator.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/equip_player.js
+++ b/Commands/equip_player.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/equip_player.js
+++ b/Commands/equip_player.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/equip_player.js
+++ b/Commands/equip_player.js
@@ -2,7 +2,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/exit_moderator.js
+++ b/Commands/exit_moderator.js
@@ -30,7 +30,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/exit_moderator.js
+++ b/Commands/exit_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/exit_moderator.js
+++ b/Commands/exit_moderator.js
@@ -30,7 +30,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/find_moderator.js
+++ b/Commands/find_moderator.js
@@ -72,7 +72,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/find_moderator.js
+++ b/Commands/find_moderator.js
@@ -72,7 +72,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/find_moderator.js
+++ b/Commands/find_moderator.js
@@ -8,7 +8,6 @@ import ItemInstance from '../Data/ItemInstance.js';
 import Player from '../Data/Player.js';
 import Puzzle from '../Data/Puzzle.js';
 import Recipe from '../Data/Recipe.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 import * as finder from '../Modules/finder.js';

--- a/Commands/fixture_moderator.js
+++ b/Commands/fixture_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 import Narration from '../Data/Narration.js';

--- a/Commands/fixture_moderator.js
+++ b/Commands/fixture_moderator.js
@@ -39,7 +39,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/fixture_moderator.js
+++ b/Commands/fixture_moderator.js
@@ -39,7 +39,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/flag_moderator.js
+++ b/Commands/flag_moderator.js
@@ -41,7 +41,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/flag_moderator.js
+++ b/Commands/flag_moderator.js
@@ -41,7 +41,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/flag_moderator.js
+++ b/Commands/flag_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import Flag from '../Data/Flag.js';
 

--- a/Commands/gesture_moderator.js
+++ b/Commands/gesture_moderator.js
@@ -31,7 +31,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/gesture_moderator.js
+++ b/Commands/gesture_moderator.js
@@ -1,7 +1,6 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import ItemInstance from '../Data/ItemInstance.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { createPaginatedEmbed } from '../Modules/helpers.js';
 

--- a/Commands/gesture_moderator.js
+++ b/Commands/gesture_moderator.js
@@ -31,7 +31,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/gesture_player.js
+++ b/Commands/gesture_player.js
@@ -35,7 +35,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/gesture_player.js
+++ b/Commands/gesture_player.js
@@ -6,7 +6,6 @@ import Player from '../Data/Player.js';
 import Puzzle from '../Data/Puzzle.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { createPaginatedEmbed } from '../Modules/helpers.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/gesture_player.js
+++ b/Commands/gesture_player.js
@@ -35,7 +35,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/give_moderator.js
+++ b/Commands/give_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/give_moderator.js
+++ b/Commands/give_moderator.js
@@ -27,7 +27,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/give_moderator.js
+++ b/Commands/give_moderator.js
@@ -27,7 +27,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/give_player.js
+++ b/Commands/give_player.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/give_player.js
+++ b/Commands/give_player.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/give_player.js
+++ b/Commands/give_player.js
@@ -2,7 +2,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 import Narration from '../Data/Narration.js';
 

--- a/Commands/help_eligible.js
+++ b/Commands/help_eligible.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/help_eligible.js
+++ b/Commands/help_eligible.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { createPaginatedEmbed } from '../Modules/helpers.js';
 

--- a/Commands/help_eligible.js
+++ b/Commands/help_eligible.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/help_moderator.js
+++ b/Commands/help_moderator.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/help_moderator.js
+++ b/Commands/help_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { createPaginatedEmbed } from '../Modules/helpers.js';
 

--- a/Commands/help_moderator.js
+++ b/Commands/help_moderator.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/help_player.js
+++ b/Commands/help_player.js
@@ -26,7 +26,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/help_player.js
+++ b/Commands/help_player.js
@@ -26,7 +26,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/help_player.js
+++ b/Commands/help_player.js
@@ -3,7 +3,6 @@ import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { createPaginatedEmbed } from '../Modules/helpers.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/hide_moderator.js
+++ b/Commands/hide_moderator.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/hide_moderator.js
+++ b/Commands/hide_moderator.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/hide_moderator.js
+++ b/Commands/hide_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 import Whisper from '../Data/Whisper.js';

--- a/Commands/hide_player.js
+++ b/Commands/hide_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 import Whisper from '../Data/Whisper.js';
 
 /** @type {CommandConfig} */

--- a/Commands/hide_player.js
+++ b/Commands/hide_player.js
@@ -33,7 +33,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/hide_player.js
+++ b/Commands/hide_player.js
@@ -33,7 +33,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/inspect_moderator.js
+++ b/Commands/inspect_moderator.js
@@ -3,7 +3,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 import Narration from '../Data/Narration.js';

--- a/Commands/inspect_moderator.js
+++ b/Commands/inspect_moderator.js
@@ -45,7 +45,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/inspect_moderator.js
+++ b/Commands/inspect_moderator.js
@@ -45,7 +45,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/inspect_player.js
+++ b/Commands/inspect_player.js
@@ -46,7 +46,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/inspect_player.js
+++ b/Commands/inspect_player.js
@@ -46,7 +46,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/inspect_player.js
+++ b/Commands/inspect_player.js
@@ -5,7 +5,6 @@ import RoomItem from "../Data/RoomItem.js";
 import Player from '../Data/Player.js';
 import Puzzle from "../Data/Puzzle.js";
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 import Narration from '../Data/Narration.js';
 
 /** @type {CommandConfig} */

--- a/Commands/instantiate_moderator.js
+++ b/Commands/instantiate_moderator.js
@@ -1,7 +1,6 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import RoomItem from '../Data/RoomItem.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { instantiateItem, instantiateInventoryItem } from '../Modules/itemManager.js';
 

--- a/Commands/instantiate_moderator.js
+++ b/Commands/instantiate_moderator.js
@@ -42,7 +42,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/instantiate_moderator.js
+++ b/Commands/instantiate_moderator.js
@@ -42,7 +42,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/inventory_moderator.js
+++ b/Commands/inventory_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/inventory_moderator.js
+++ b/Commands/inventory_moderator.js
@@ -23,7 +23,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/inventory_moderator.js
+++ b/Commands/inventory_moderator.js
@@ -23,7 +23,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/inventory_player.js
+++ b/Commands/inventory_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/inventory_player.js
+++ b/Commands/inventory_player.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/inventory_player.js
+++ b/Commands/inventory_player.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/kill_moderator.js
+++ b/Commands/kill_moderator.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/kill_moderator.js
+++ b/Commands/kill_moderator.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/kill_moderator.js
+++ b/Commands/kill_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/knock_moderator.js
+++ b/Commands/knock_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 import Narration from '../Data/Narration.js';

--- a/Commands/knock_moderator.js
+++ b/Commands/knock_moderator.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/knock_moderator.js
+++ b/Commands/knock_moderator.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/knock_player.js
+++ b/Commands/knock_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 import Narration from '../Data/Narration.js';
 
 /** @type {CommandConfig} */

--- a/Commands/knock_player.js
+++ b/Commands/knock_player.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/knock_player.js
+++ b/Commands/knock_player.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/living_moderator.js
+++ b/Commands/living_moderator.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/living_moderator.js
+++ b/Commands/living_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/living_moderator.js
+++ b/Commands/living_moderator.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/load_moderator.js
+++ b/Commands/load_moderator.js
@@ -1,7 +1,6 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import * as loader from '../Modules/loader.js';
 

--- a/Commands/load_moderator.js
+++ b/Commands/load_moderator.js
@@ -43,7 +43,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/load_moderator.js
+++ b/Commands/load_moderator.js
@@ -43,7 +43,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/location_moderator.js
+++ b/Commands/location_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/location_moderator.js
+++ b/Commands/location_moderator.js
@@ -23,7 +23,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/location_moderator.js
+++ b/Commands/location_moderator.js
@@ -23,7 +23,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/move_moderator.js
+++ b/Commands/move_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/move_moderator.js
+++ b/Commands/move_moderator.js
@@ -29,7 +29,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/move_moderator.js
+++ b/Commands/move_moderator.js
@@ -29,7 +29,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/move_player.js
+++ b/Commands/move_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/move_player.js
+++ b/Commands/move_player.js
@@ -33,7 +33,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/move_player.js
+++ b/Commands/move_player.js
@@ -33,7 +33,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/occupants_moderator.js
+++ b/Commands/occupants_moderator.js
@@ -30,7 +30,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/occupants_moderator.js
+++ b/Commands/occupants_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 import dayjs from 'dayjs';

--- a/Commands/occupants_moderator.js
+++ b/Commands/occupants_moderator.js
@@ -30,7 +30,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/ongoing_moderator.js
+++ b/Commands/ongoing_moderator.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/ongoing_moderator.js
+++ b/Commands/ongoing_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/ongoing_moderator.js
+++ b/Commands/ongoing_moderator.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/online_moderator.js
+++ b/Commands/online_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/online_moderator.js
+++ b/Commands/online_moderator.js
@@ -23,7 +23,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/online_moderator.js
+++ b/Commands/online_moderator.js
@@ -23,7 +23,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/play_eligible.js
+++ b/Commands/play_eligible.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/play_eligible.js
+++ b/Commands/play_eligible.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/play_eligible.js
+++ b/Commands/play_eligible.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import playerdefaults from '../Configs/playerdefaults.json' with { type: 'json' };
 import Player from '../Data/Player.js';
 

--- a/Commands/puzzle_moderator.js
+++ b/Commands/puzzle_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/puzzle_moderator.js
+++ b/Commands/puzzle_moderator.js
@@ -41,7 +41,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/puzzle_moderator.js
+++ b/Commands/puzzle_moderator.js
@@ -41,7 +41,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/recipes_player.js
+++ b/Commands/recipes_player.js
@@ -6,7 +6,6 @@ import Prefab from '../Data/Prefab.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { createPaginatedEmbed } from '../Modules/helpers.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/recipes_player.js
+++ b/Commands/recipes_player.js
@@ -42,7 +42,7 @@ var fixtureRecipesDescription = "";
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/recipes_player.js
+++ b/Commands/recipes_player.js
@@ -42,7 +42,7 @@ var fixtureRecipesDescription = "";
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/restore_moderator.js
+++ b/Commands/restore_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/restore_moderator.js
+++ b/Commands/restore_moderator.js
@@ -23,7 +23,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/restore_moderator.js
+++ b/Commands/restore_moderator.js
@@ -23,7 +23,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/reveal_moderator.js
+++ b/Commands/reveal_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/reveal_moderator.js
+++ b/Commands/reveal_moderator.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/reveal_moderator.js
+++ b/Commands/reveal_moderator.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/roll_moderator.js
+++ b/Commands/roll_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 import Die from '../Data/Die.js';

--- a/Commands/roll_moderator.js
+++ b/Commands/roll_moderator.js
@@ -37,7 +37,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/roll_moderator.js
+++ b/Commands/roll_moderator.js
@@ -37,7 +37,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/run_player.js
+++ b/Commands/run_player.js
@@ -32,7 +32,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/run_player.js
+++ b/Commands/run_player.js
@@ -32,7 +32,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/run_player.js
+++ b/Commands/run_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/save_moderator.js
+++ b/Commands/save_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { saveGame } from '../Modules/saver.js';
 

--- a/Commands/save_moderator.js
+++ b/Commands/save_moderator.js
@@ -26,7 +26,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/save_moderator.js
+++ b/Commands/save_moderator.js
@@ -26,7 +26,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/say_moderator.js
+++ b/Commands/say_moderator.js
@@ -32,7 +32,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/say_moderator.js
+++ b/Commands/say_moderator.js
@@ -1,6 +1,6 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { ChannelType, Message } from 'discord.js';
+import { ChannelType } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { default as handleDialog } from '../Modules/dialogHandler.js';
 

--- a/Commands/say_moderator.js
+++ b/Commands/say_moderator.js
@@ -32,7 +32,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/say_player.js
+++ b/Commands/say_player.js
@@ -27,7 +27,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/say_player.js
+++ b/Commands/say_player.js
@@ -2,7 +2,7 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message, ChannelType } from "discord.js";
+import { ChannelType } from "discord.js";
 import { default as handleDialog } from '../Modules/dialogHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/say_player.js
+++ b/Commands/say_player.js
@@ -27,7 +27,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/set_moderator.js
+++ b/Commands/set_moderator.js
@@ -34,7 +34,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/set_moderator.js
+++ b/Commands/set_moderator.js
@@ -34,7 +34,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/set_moderator.js
+++ b/Commands/set_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { getChildItems } from '../Modules/itemManager.js';
 

--- a/Commands/setdefaultroomicon_moderator.js
+++ b/Commands/setdefaultroomicon_moderator.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setdefaultroomicon_moderator.js
+++ b/Commands/setdefaultroomicon_moderator.js
@@ -1,7 +1,6 @@
 import settings from '../Configs/settings.json' with { type: 'json' };
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 import fs from 'fs';

--- a/Commands/setdefaultroomicon_moderator.js
+++ b/Commands/setdefaultroomicon_moderator.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setdest_moderator.js
+++ b/Commands/setdest_moderator.js
@@ -42,7 +42,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setdest_moderator.js
+++ b/Commands/setdest_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/setdest_moderator.js
+++ b/Commands/setdest_moderator.js
@@ -42,7 +42,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setdisplayicon_moderator.js
+++ b/Commands/setdisplayicon_moderator.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setdisplayicon_moderator.js
+++ b/Commands/setdisplayicon_moderator.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setdisplayicon_moderator.js
+++ b/Commands/setdisplayicon_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/setdisplayname_moderator.js
+++ b/Commands/setdisplayname_moderator.js
@@ -28,7 +28,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setdisplayname_moderator.js
+++ b/Commands/setdisplayname_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/setdisplayname_moderator.js
+++ b/Commands/setdisplayname_moderator.js
@@ -28,7 +28,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setpronouns_moderator.js
+++ b/Commands/setpronouns_moderator.js
@@ -34,7 +34,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setpronouns_moderator.js
+++ b/Commands/setpronouns_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/setpronouns_moderator.js
+++ b/Commands/setpronouns_moderator.js
@@ -34,7 +34,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setupdemo_moderator.js
+++ b/Commands/setupdemo_moderator.js
@@ -36,7 +36,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setupdemo_moderator.js
+++ b/Commands/setupdemo_moderator.js
@@ -36,7 +36,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setupdemo_moderator.js
+++ b/Commands/setupdemo_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { setupdemo } from '../Modules/saver.js';
 import { registerRoomCategory, createCategory } from '../Modules/serverManager.js';

--- a/Commands/setvoice_moderator.js
+++ b/Commands/setvoice_moderator.js
@@ -38,7 +38,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/setvoice_moderator.js
+++ b/Commands/setvoice_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/setvoice_moderator.js
+++ b/Commands/setvoice_moderator.js
@@ -38,7 +38,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/sleep_player.js
+++ b/Commands/sleep_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/sleep_player.js
+++ b/Commands/sleep_player.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/sleep_player.js
+++ b/Commands/sleep_player.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/startgame_moderator.js
+++ b/Commands/startgame_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import playerdefaults from '../Configs/playerdefaults.json' with { type: 'json' };
 import { updateSheetValues } from '../Modules/sheets.js';
 

--- a/Commands/startgame_moderator.js
+++ b/Commands/startgame_moderator.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/startgame_moderator.js
+++ b/Commands/startgame_moderator.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/stash_moderator.js
+++ b/Commands/stash_moderator.js
@@ -30,7 +30,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/stash_moderator.js
+++ b/Commands/stash_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/stash_moderator.js
+++ b/Commands/stash_moderator.js
@@ -30,7 +30,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/stash_player.js
+++ b/Commands/stash_player.js
@@ -31,7 +31,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/stash_player.js
+++ b/Commands/stash_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/stash_player.js
+++ b/Commands/stash_player.js
@@ -31,7 +31,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/stats_moderator.js
+++ b/Commands/stats_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/stats_moderator.js
+++ b/Commands/stats_moderator.js
@@ -26,7 +26,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/stats_moderator.js
+++ b/Commands/stats_moderator.js
@@ -26,7 +26,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/status_moderator.js
+++ b/Commands/status_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/status_moderator.js
+++ b/Commands/status_moderator.js
@@ -41,7 +41,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/status_moderator.js
+++ b/Commands/status_moderator.js
@@ -41,7 +41,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/status_player.js
+++ b/Commands/status_player.js
@@ -24,7 +24,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/status_player.js
+++ b/Commands/status_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/status_player.js
+++ b/Commands/status_player.js
@@ -24,7 +24,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/steal_player.js
+++ b/Commands/steal_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/steal_player.js
+++ b/Commands/steal_player.js
@@ -36,7 +36,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/steal_player.js
+++ b/Commands/steal_player.js
@@ -36,7 +36,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/stop_player.js
+++ b/Commands/stop_player.js
@@ -27,7 +27,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/stop_player.js
+++ b/Commands/stop_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 import Narration from '../Data/Narration.js';
 
 /** @type {CommandConfig} */

--- a/Commands/stop_player.js
+++ b/Commands/stop_player.js
@@ -27,7 +27,7 @@ export function usage(settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/tag_moderator.js
+++ b/Commands/tag_moderator.js
@@ -34,7 +34,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/tag_moderator.js
+++ b/Commands/tag_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/tag_moderator.js
+++ b/Commands/tag_moderator.js
@@ -34,7 +34,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/take_moderator.js
+++ b/Commands/take_moderator.js
@@ -3,7 +3,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/take_moderator.js
+++ b/Commands/take_moderator.js
@@ -33,7 +33,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/take_moderator.js
+++ b/Commands/take_moderator.js
@@ -33,7 +33,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/take_player.js
+++ b/Commands/take_player.js
@@ -37,7 +37,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/take_player.js
+++ b/Commands/take_player.js
@@ -5,7 +5,6 @@ import RoomItem from '../Data/RoomItem.js';
 import Player from '../Data/Player.js';
 import Puzzle from "../Data/Puzzle.js";
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 import Narration from '../Data/Narration.js';
 
 /** @type {CommandConfig} */

--- a/Commands/take_player.js
+++ b/Commands/take_player.js
@@ -37,7 +37,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/testparser_moderator.js
+++ b/Commands/testparser_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import playerdefaults from '../Configs/playerdefaults.json' with { type: 'json' };
 import { parseDescription, parseDescriptionWithErrors, addItem, removeItem } from '../Modules/parser.js';

--- a/Commands/testparser_moderator.js
+++ b/Commands/testparser_moderator.js
@@ -48,7 +48,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/testparser_moderator.js
+++ b/Commands/testparser_moderator.js
@@ -48,7 +48,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/testspeeds_moderator.js
+++ b/Commands/testspeeds_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import fs from 'fs';
 import { EOL } from 'os';

--- a/Commands/testspeeds_moderator.js
+++ b/Commands/testspeeds_moderator.js
@@ -32,7 +32,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/testspeeds_moderator.js
+++ b/Commands/testspeeds_moderator.js
@@ -32,7 +32,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/text_moderator.js
+++ b/Commands/text_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/text_moderator.js
+++ b/Commands/text_moderator.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/text_moderator.js
+++ b/Commands/text_moderator.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/text_player.js
+++ b/Commands/text_player.js
@@ -27,7 +27,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/text_player.js
+++ b/Commands/text_player.js
@@ -2,7 +2,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/text_player.js
+++ b/Commands/text_player.js
@@ -27,7 +27,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/time_player.js
+++ b/Commands/time_player.js
@@ -2,7 +2,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/time_player.js
+++ b/Commands/time_player.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/time_player.js
+++ b/Commands/time_player.js
@@ -25,7 +25,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/trigger_moderator.js
+++ b/Commands/trigger_moderator.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/trigger_moderator.js
+++ b/Commands/trigger_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/trigger_moderator.js
+++ b/Commands/trigger_moderator.js
@@ -24,7 +24,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/uncraft_moderator.js
+++ b/Commands/uncraft_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/uncraft_moderator.js
+++ b/Commands/uncraft_moderator.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/uncraft_moderator.js
+++ b/Commands/uncraft_moderator.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/uncraft_player.js
+++ b/Commands/uncraft_player.js
@@ -2,7 +2,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/uncraft_player.js
+++ b/Commands/uncraft_player.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/uncraft_player.js
+++ b/Commands/uncraft_player.js
@@ -29,7 +29,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/undress_moderator.js
+++ b/Commands/undress_moderator.js
@@ -31,7 +31,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/undress_moderator.js
+++ b/Commands/undress_moderator.js
@@ -3,7 +3,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/undress_moderator.js
+++ b/Commands/undress_moderator.js
@@ -31,7 +31,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/undress_player.js
+++ b/Commands/undress_player.js
@@ -32,7 +32,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/undress_player.js
+++ b/Commands/undress_player.js
@@ -32,7 +32,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/undress_player.js
+++ b/Commands/undress_player.js
@@ -5,7 +5,6 @@ import RoomItem from "../Data/RoomItem.js";
 import Player from '../Data/Player.js';
 import Puzzle from "../Data/Puzzle.js";
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/unequip_moderator.js
+++ b/Commands/unequip_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/unequip_moderator.js
+++ b/Commands/unequip_moderator.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/unequip_moderator.js
+++ b/Commands/unequip_moderator.js
@@ -28,7 +28,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/unequip_player.js
+++ b/Commands/unequip_player.js
@@ -27,7 +27,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/unequip_player.js
+++ b/Commands/unequip_player.js
@@ -2,7 +2,6 @@ import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/unequip_player.js
+++ b/Commands/unequip_player.js
@@ -27,7 +27,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/unstash_moderator.js
+++ b/Commands/unstash_moderator.js
@@ -30,7 +30,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/unstash_moderator.js
+++ b/Commands/unstash_moderator.js
@@ -1,7 +1,6 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
 import InventoryItem from '../Data/InventoryItem.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/unstash_moderator.js
+++ b/Commands/unstash_moderator.js
@@ -30,7 +30,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/unstash_player.js
+++ b/Commands/unstash_player.js
@@ -31,7 +31,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/unstash_player.js
+++ b/Commands/unstash_player.js
@@ -3,7 +3,6 @@ import Game from '../Data/Game.js';
 import InventoryItem from '../Data/InventoryItem.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/unstash_player.js
+++ b/Commands/unstash_player.js
@@ -31,7 +31,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/use_moderator.js
+++ b/Commands/use_moderator.js
@@ -30,7 +30,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/use_moderator.js
+++ b/Commands/use_moderator.js
@@ -1,6 +1,5 @@
 ﻿import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 
 /** @type {CommandConfig} */

--- a/Commands/use_moderator.js
+++ b/Commands/use_moderator.js
@@ -30,7 +30,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */

--- a/Commands/use_player.js
+++ b/Commands/use_player.js
@@ -43,7 +43,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/use_player.js
+++ b/Commands/use_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/use_player.js
+++ b/Commands/use_player.js
@@ -43,7 +43,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/wake_player.js
+++ b/Commands/wake_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/wake_player.js
+++ b/Commands/wake_player.js
@@ -26,7 +26,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/wake_player.js
+++ b/Commands/wake_player.js
@@ -26,7 +26,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/whisper_moderator.js
+++ b/Commands/whisper_moderator.js
@@ -36,7 +36,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */
@@ -122,7 +122,7 @@ export async function execute (game, message, command, args) {
 /**
  * 
  * @param {Game} game - The game the whisper is occurring in.
- * @param {Message} message - The Discord message that triggered this.
+ * @param {AEMessage} message - The Discord message that triggered this.
  * @param {string} messageText - The text of the message to send.
  * @param {Player} npc - The NPC player whispering this message.
  * @param {Whisper} whisper - The whisper this is occurring in.

--- a/Commands/whisper_moderator.js
+++ b/Commands/whisper_moderator.js
@@ -36,7 +36,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  */
@@ -122,7 +122,7 @@ export async function execute (game, message, command, args) {
 /**
  * 
  * @param {Game} game - The game the whisper is occurring in.
- * @param {AEMessage} message - The Discord message that triggered this.
+ * @param {UserMessage} message - The Discord message that triggered this.
  * @param {string} messageText - The text of the message to send.
  * @param {Player} npc - The NPC player whispering this message.
  * @param {Whisper} whisper - The whisper this is occurring in.

--- a/Commands/whisper_moderator.js
+++ b/Commands/whisper_moderator.js
@@ -1,6 +1,5 @@
 import GameSettings from '../Classes/GameSettings.js';
 import Game from '../Data/Game.js';
-import { Message } from 'discord.js';
 import * as messageHandler from '../Modules/messageHandler.js';
 import { default as handleDialog } from '../Modules/dialogHandler.js';
 

--- a/Commands/whisper_player.js
+++ b/Commands/whisper_player.js
@@ -2,7 +2,6 @@
 import Game from '../Data/Game.js';
 import Player from '../Data/Player.js';
 import * as messageHandler from '../Modules/messageHandler.js';
-import { Message } from "discord.js";
 import Whisper from '../Data/Whisper.js';
 
 /** @type {CommandConfig} */

--- a/Commands/whisper_player.js
+++ b/Commands/whisper_player.js
@@ -31,7 +31,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {AEMessage} message - The message in which the command was issued. 
+ * @param {UserMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Commands/whisper_player.js
+++ b/Commands/whisper_player.js
@@ -31,7 +31,7 @@ export function usage (settings) {
 
 /**
  * @param {Game} game - The game in which the command is being executed. 
- * @param {Message} message - The message in which the command was issued. 
+ * @param {AEMessage} message - The message in which the command was issued. 
  * @param {string} command - The command alias that was used. 
  * @param {string[]} args - A list of arguments passed to the command as individual words. 
  * @param {Player} player - The player who issued the command. 

--- a/Data/Player.js
+++ b/Data/Player.js
@@ -1783,7 +1783,7 @@ export default class Player extends ItemContainer {
      * @param {string} password - The password the player entered to attempt the puzzle.
      * @param {string} command - The command alias that was used to attempt the puzzle.
      * @param {string} input - The combined arguments of the command.
-     * @param {AEMessage} [message] - The message that triggered the puzzle attempt.
+     * @param {UserMessage} [message] - The message that triggered the puzzle attempt.
      * @param {Player} [targetPlayer] - The player who will be treated as the initiating player in subsequent bot command executions called by the puzzle's solved commands, if applicable.
      * @returns {string|void} A message to show to the player indicating why their attempt failed.
      */

--- a/Data/Player.js
+++ b/Data/Player.js
@@ -25,7 +25,7 @@ import * as messageHandler from '../Modules/messageHandler.js';
 
 import Timer from '../Classes/Timer.js';
 
-import { Collection, GuildMember, Message, TextChannel } from 'discord.js';
+import { Collection, GuildMember, TextChannel } from 'discord.js';
 import dayjs from 'dayjs';
 
 dayjs().format();

--- a/Data/Player.js
+++ b/Data/Player.js
@@ -1783,7 +1783,7 @@ export default class Player extends ItemContainer {
      * @param {string} password - The password the player entered to attempt the puzzle.
      * @param {string} command - The command alias that was used to attempt the puzzle.
      * @param {string} input - The combined arguments of the command.
-     * @param {Message} [message] - The message that triggered the puzzle attempt.
+     * @param {AEMessage} [message] - The message that triggered the puzzle attempt.
      * @param {Player} [targetPlayer] - The player who will be treated as the initiating player in subsequent bot command executions called by the puzzle's solved commands, if applicable.
      * @returns {string|void} A message to show to the player indicating why their attempt failed.
      */

--- a/Data/Puzzle.js
+++ b/Data/Puzzle.js
@@ -382,7 +382,7 @@ export default class Puzzle extends ItemContainer {
      * @param {string} narration - The message to be narrated in the room.
      * @param {string} command - The command alias that was used to attempt the puzzle.
      * @param {string} input - The combined arguments of the command.
-     * @param {Message} [message] - The message that triggered the puzzle attempt.
+     * @param {AEMessage} [message] - The message that triggered the puzzle attempt.
      */
     requirementsNotMet(player, narration, command, input, message) {
         // If there's no text in the Requirements Not Met cell, then the player shouldn't know about this puzzle.

--- a/Data/Puzzle.js
+++ b/Data/Puzzle.js
@@ -382,7 +382,7 @@ export default class Puzzle extends ItemContainer {
      * @param {string} narration - The message to be narrated in the room.
      * @param {string} command - The command alias that was used to attempt the puzzle.
      * @param {string} input - The combined arguments of the command.
-     * @param {AEMessage} [message] - The message that triggered the puzzle attempt.
+     * @param {UserMessage} [message] - The message that triggered the puzzle attempt.
      */
     requirementsNotMet(player, narration, command, input, message) {
         // If there's no text in the Requirements Not Met cell, then the player shouldn't know about this puzzle.

--- a/Data/Puzzle.js
+++ b/Data/Puzzle.js
@@ -13,7 +13,6 @@ import RoomItem from './RoomItem.js';
 import { parseAndExecuteBotCommands } from '../Modules/commandHandler.js';
 import { addLogMessage, addReply } from '../Modules/messageHandler.js';
 import { addItem as addItemToList, removeItem as removeItemFromList } from "../Modules/parser.js";
-import { Message } from 'discord.js';
 
 
 /**

--- a/Modules/commandHandler.js
+++ b/Modules/commandHandler.js
@@ -11,7 +11,7 @@ import { ChannelType, Message } from 'discord.js';
  * Finds the right command file for the user and executes it.
  * @param {string} commandStr - The full text of the command issued.
  * @param {Game} game - The game in which the command is being executed.
- * @param {Message} [message] - The message in which the command was issued, if applicable.
+ * @param {AEMessage} [message] - The message in which the command was issued, if applicable.
  * @param {Player} [player] - The player who issued the command, or caused it to be executed, if applicable.
  * @param {Event|Flag|InventoryItem|Puzzle} [callee] - The in-game entity that caused the command to be executed, if applicable.
  * @returns {Promise<boolean>} Whether the command was successfully executed.

--- a/Modules/commandHandler.js
+++ b/Modules/commandHandler.js
@@ -11,7 +11,7 @@ import { ChannelType, Message } from 'discord.js';
  * Finds the right command file for the user and executes it.
  * @param {string} commandStr - The full text of the command issued.
  * @param {Game} game - The game in which the command is being executed.
- * @param {AEMessage} [message] - The message in which the command was issued, if applicable.
+ * @param {UserMessage} [message] - The message in which the command was issued, if applicable.
  * @param {Player} [player] - The player who issued the command, or caused it to be executed, if applicable.
  * @param {Event|Flag|InventoryItem|Puzzle} [callee] - The in-game entity that caused the command to be executed, if applicable.
  * @returns {Promise<boolean>} Whether the command was successfully executed.

--- a/Modules/commandHandler.js
+++ b/Modules/commandHandler.js
@@ -5,7 +5,7 @@ import InventoryItem from '../Data/InventoryItem.js';
 import Player from '../Data/Player.js';
 import Puzzle from '../Data/Puzzle.js';
 import { addReply, addGameMechanicMessage } from './messageHandler.js';
-import { ChannelType, Message } from 'discord.js';
+import { ChannelType } from 'discord.js';
 
 /**
  * Finds the right command file for the user and executes it.

--- a/Modules/dialogHandler.js
+++ b/Modules/dialogHandler.js
@@ -3,7 +3,7 @@ import Player from '../Data/Player.js';
 import Room from '../Data/Room.js';
 import Whisper from '../Data/Whisper.js';
 import * as messageHandler from './messageHandler.js';
-import { ChannelType, Message } from 'discord.js';
+import { ChannelType } from 'discord.js';
 
 /**
  * Interprets a dialog message and executes behavior caused by it.

--- a/Modules/dialogHandler.js
+++ b/Modules/dialogHandler.js
@@ -8,7 +8,7 @@ import { ChannelType, Message } from 'discord.js';
 /**
  * Interprets a dialog message and executes behavior caused by it.
  * @param {Game} game - The game in which the dialog was sent.
- * @param {Message} message - The message which sent the dialog.
+ * @param {AEMessage} message - The message which sent the dialog.
  * @param {boolean} deletable - Whether the dialog message can be deleted by the bot. If it was sent in a DM channel, it can't be deleted.
  * @param {Player} [player] - The player who sent the dialog.
  * @param {string} [originalDisplayName] - The original displayName of the player who sent the dialog, in case their real displayName needs to be hidden.

--- a/Modules/dialogHandler.js
+++ b/Modules/dialogHandler.js
@@ -8,7 +8,7 @@ import { ChannelType, Message } from 'discord.js';
 /**
  * Interprets a dialog message and executes behavior caused by it.
  * @param {Game} game - The game in which the dialog was sent.
- * @param {AEMessage} message - The message which sent the dialog.
+ * @param {UserMessage} message - The message which sent the dialog.
  * @param {boolean} deletable - Whether the dialog message can be deleted by the bot. If it was sent in a DM channel, it can't be deleted.
  * @param {Player} [player] - The player who sent the dialog.
  * @param {string} [originalDisplayName] - The original displayName of the player who sent the dialog, in case their real displayName needs to be hidden.

--- a/Modules/messageHandler.js
+++ b/Modules/messageHandler.js
@@ -316,7 +316,7 @@ export function addGameMechanicMessage(game, channel, messageText) {
 /**
  * Replies to a message. This is usually done when a user has sent a message with an error.
  * @param {Game} game - The game this message was sent in.
- * @param {AEMessage} message - The message to reply to.
+ * @param {UserMessage} message - The message to reply to.
  * @param {string} messageText - The text to send in response.
  */
 export async function addReply(game, message, messageText) {
@@ -338,7 +338,7 @@ export async function addReply(game, message, messageText) {
  * Mirrors a dialog message in a spectate channel.
  * @param {Player} player - The player whose spectate channel this message is being sent to.
  * @param {Player|PseudoPlayer} speaker - The player who originally sent the dialog message.
- * @param {AEMessage} message - The message in which this dialog originated.
+ * @param {UserMessage} message - The message in which this dialog originated.
  * @param {Whisper} [whisper] - The whisper the dialog was sent in, if applicable.
  * @param {string} [displayName] - The displayName to use for the mirrored webhook message. If none is specified, the speaker's current displayName will be used.
  */
@@ -386,7 +386,7 @@ export async function addSpectatedPlayerMessage(player, speaker, message, whispe
  * Edits spectate messages when the dialog they mirror is edited.
  * @param {Game} game - The game this dialog belongs to.
  * @param {Message|import('discord.js').PartialMessage} messageOld - The original message being edited.
- * @param {AEMessage} messageNew - The new message after being edited.
+ * @param {UserMessage} messageNew - The new message after being edited.
  */
 export async function editSpectatorMessage(game, messageOld, messageNew) {
     const cachedMessage = game.dialogCache.find((entry) => entry.messageId === messageOld.id);

--- a/Modules/messageHandler.js
+++ b/Modules/messageHandler.js
@@ -1,4 +1,4 @@
-import { TextDisplayBuilder, ThumbnailBuilder, SectionBuilder, ContainerBuilder, SeparatorBuilder, SeparatorSpacingSize, MessageFlags, Message, ChannelType, Attachment, Collection } from 'discord.js';
+import { TextDisplayBuilder, ThumbnailBuilder, SectionBuilder, ContainerBuilder, SeparatorBuilder, SeparatorSpacingSize, MessageFlags, ChannelType, Attachment, Collection } from 'discord.js';
 import Player from '../Data/Player.js';
 import Whisper from '../Data/Whisper.js';
 import Game from '../Data/Game.js';
@@ -385,7 +385,7 @@ export async function addSpectatedPlayerMessage(player, speaker, message, whispe
 /**
  * Edits spectate messages when the dialog they mirror is edited.
  * @param {Game} game - The game this dialog belongs to.
- * @param {Message|import('discord.js').PartialMessage} messageOld - The original message being edited.
+ * @param {UserMessage|import('discord.js').PartialMessage} messageOld - The original message being edited.
  * @param {UserMessage} messageNew - The new message after being edited.
  */
 export async function editSpectatorMessage(game, messageOld, messageNew) {

--- a/Modules/messageHandler.js
+++ b/Modules/messageHandler.js
@@ -1,4 +1,4 @@
-import { TextDisplayBuilder, ThumbnailBuilder, SectionBuilder, ContainerBuilder, SeparatorBuilder, SeparatorSpacingSize, MessageFlags, Message, ChannelType, Attachment, TextChannel, DMChannel, Collection } from 'discord.js';
+import { TextDisplayBuilder, ThumbnailBuilder, SectionBuilder, ContainerBuilder, SeparatorBuilder, SeparatorSpacingSize, MessageFlags, Message, ChannelType, Attachment, Collection } from 'discord.js';
 import Player from '../Data/Player.js';
 import Whisper from '../Data/Whisper.js';
 import Game from '../Data/Game.js';
@@ -226,7 +226,7 @@ export async function addRoomDescription(player, location, descriptionText, defa
 /**
  * Sends the help menu for a command as an array of Discord Components.
  * @param {Game} game - The game context in which this help menu is being sent.
- * @param {TextChannel|DMChannel} channel - The channel to send the help menu to.
+ * @param {Messageable} channel - The channel to send the help menu to.
  * @param {Command} command - The command to display the help menu for.
  */
 export async function addCommandHelp(game, channel, command) {
@@ -301,7 +301,7 @@ export async function addLogMessage(game, messageText) {
 /**
  * Sends a standard message indicating the outcome of a game mechanic in the specified channel.
  * @param {Game} game - The game in which this mechanic is occurring.
- * @param {TextChannel} channel - The channel to send the message to.
+ * @param {Messageable} channel - The channel to send the message to.
  * @param {string} messageText - The message to send.
  */
 export function addGameMechanicMessage(game, channel, messageText) {
@@ -309,14 +309,14 @@ export function addGameMechanicMessage(game, channel, messageText) {
         {
             fire: async () => await channel.send(messageText),
         },
-        channel.parent !== undefined && channel.id === game.guildContext.commandChannel.id ? "mod" : "mechanic"
+        channel.id === game.guildContext.commandChannel.id ? "mod" : "mechanic"
     );
 }
 
 /**
  * Replies to a message. This is usually done when a user has sent a message with an error.
  * @param {Game} game - The game this message was sent in.
- * @param {Message} message - The message to reply to.
+ * @param {AEMessage} message - The message to reply to.
  * @param {string} messageText - The text to send in response.
  */
 export async function addReply(game, message, messageText) {
@@ -338,7 +338,7 @@ export async function addReply(game, message, messageText) {
  * Mirrors a dialog message in a spectate channel.
  * @param {Player} player - The player whose spectate channel this message is being sent to.
  * @param {Player|PseudoPlayer} speaker - The player who originally sent the dialog message.
- * @param {Message} message - The message in which this dialog originated.
+ * @param {AEMessage} message - The message in which this dialog originated.
  * @param {Whisper} [whisper] - The whisper the dialog was sent in, if applicable.
  * @param {string} [displayName] - The displayName to use for the mirrored webhook message. If none is specified, the speaker's current displayName will be used.
  */
@@ -386,7 +386,7 @@ export async function addSpectatedPlayerMessage(player, speaker, message, whispe
  * Edits spectate messages when the dialog they mirror is edited.
  * @param {Game} game - The game this dialog belongs to.
  * @param {Message|import('discord.js').PartialMessage} messageOld - The original message being edited.
- * @param {Message} messageNew - The new message after being edited.
+ * @param {AEMessage} messageNew - The new message after being edited.
  */
 export async function editSpectatorMessage(game, messageOld, messageNew) {
     const cachedMessage = game.dialogCache.find((entry) => entry.messageId === messageOld.id);

--- a/Modules/messageHandler.js
+++ b/Modules/messageHandler.js
@@ -15,7 +15,9 @@ export async function addNarration(room, messageText, addSpectate = true, speake
     if (messageText !== "") {
         room.game.messageQueue.enqueue(
             {
-                fire: async () => await room.channel.send(messageText),
+                fire: async () => {
+                    await room.channel.send(messageText);
+                },
             },
             "tell"
         );
@@ -30,7 +32,9 @@ export async function addNarration(room, messageText, addSpectate = true, speake
                 ) {
                     room.game.messageQueue.enqueue(
                         {
-                            fire: async () => await player.spectateChannel.send(messageText),
+                            fire: async () => {
+                                await player.spectateChannel.send(messageText);
+                            },
                         },
                         "spectator"
                     );
@@ -50,7 +54,9 @@ export async function addNarrationToWhisper(whisper, messageText, addSpectate = 
     if (messageText !== "") {
         whisper.game.messageQueue.enqueue(
             {
-                fire: async () => await whisper.channel.send(messageText),
+                fire: async () => {
+                    await whisper.channel.send(messageText);
+                },
             },
             "tell"
         );
@@ -64,7 +70,9 @@ export async function addNarrationToWhisper(whisper, messageText, addSpectate = 
                 ) {
                     whisper.game.messageQueue.enqueue(
                         {
-                            fire: async () => await player.spectateChannel.send(spectateMessageText),
+                            fire: async () => {
+                                await player.spectateChannel.send(spectateMessageText);
+                            },
                         },
                         "spectator"
                     );
@@ -84,7 +92,9 @@ export async function addDirectNarration(player, messageText, addSpectate = true
     if (!player.isNPC) {
         player.game.messageQueue.enqueue(
             {
-                fire: async () => await player.member.send(messageText),
+                fire: async () => {
+                    await player.member.send(messageText);
+                },
             },
             "tell"
         );
@@ -92,7 +102,9 @@ export async function addDirectNarration(player, messageText, addSpectate = true
     if (addSpectate && player.spectateChannel !== null) {
         player.game.messageQueue.enqueue(
             {
-                fire: async () => await player.spectateChannel.send(messageText),
+                fire: async () => {
+                    await player.spectateChannel.send(messageText);
+                },
             },
             "spectator"
         );
@@ -113,10 +125,12 @@ export async function addDirectNarrationWithAttachments(player, messageText, att
         player.game.messageQueue.enqueue(
             {
                 fire: async () =>
-                    await player.member.send({
-                        content: messageText,
-                        files: files,
-                    }),
+                    {
+                        await player.member.send({
+                            content: messageText,
+                            files: files,
+                        });
+                    },
             },
             "tell"
         );
@@ -124,11 +138,12 @@ export async function addDirectNarrationWithAttachments(player, messageText, att
     if (addSpectate && player.spectateChannel !== null) {
         player.game.messageQueue.enqueue(
             {
-                fire: async () =>
+                fire: async () => {
                     await player.spectateChannel.send({
                         content: messageText,
                         files: files,
-                    }),
+                    });
+                },
             },
             "spectator"
         );
@@ -199,11 +214,12 @@ export async function addRoomDescription(player, location, descriptionText, defa
         if (!player.isNPC) {
             location.game.messageQueue.enqueue(
                 {
-                    fire: async () =>
+                    fire: async () => {
                         await player.member.send({
                             components: components,
-                            flags: MessageFlags.IsComponentsV2
-                        }),
+                            flags: MessageFlags.IsComponentsV2,
+                        });
+                    },
                 },
                 "tell"
             );
@@ -211,11 +227,12 @@ export async function addRoomDescription(player, location, descriptionText, defa
         if (addSpectate && player.spectateChannel !== null) {
             location.game.messageQueue.enqueue(
                 {
-                    fire: async () =>
+                    fire: async () => {
                         await player.spectateChannel.send({
                             components: components,
-                            flags: MessageFlags.IsComponentsV2
-                        }),
+                            flags: MessageFlags.IsComponentsV2,
+                        });
+                    },
                 },
                 "spectator"
             );
@@ -275,10 +292,12 @@ export async function addCommandHelp(game, channel, command) {
     game.messageQueue.enqueue(
         {
             fire: async () =>
-                await channel.send({
-                    components: components,
-                    flags: MessageFlags.IsComponentsV2
-                })
+                {
+                    await channel.send({
+                        components: components,
+                        flags: MessageFlags.IsComponentsV2,
+                    });
+                }
         },
         channel.id === game.guildContext.commandChannel.id ? "mod" : "mechanic"
     );
@@ -292,7 +311,9 @@ export async function addCommandHelp(game, channel, command) {
 export async function addLogMessage(game, messageText) {
     game.messageQueue.enqueue(
         {
-            fire: async () => await game.guildContext.logChannel.send(messageText),
+            fire: async () => {
+                await game.guildContext.logChannel.send(messageText);
+            },
         },
         "log"
     );
@@ -307,7 +328,9 @@ export async function addLogMessage(game, messageText) {
 export function addGameMechanicMessage(game, channel, messageText) {
     game.messageQueue.enqueue(
         {
-            fire: async () => await channel.send(messageText),
+            fire: async () => {
+                await channel.send(messageText);
+            },
         },
         channel.id === game.guildContext.commandChannel.id ? "mod" : "mechanic"
     );
@@ -324,9 +347,9 @@ export async function addReply(game, message, messageText) {
         {
             fire: async () => {
                 if (message.channel.type === ChannelType.GuildText && message.channel.id === game.guildContext.commandChannel.id) {
-                    return await message.reply(messageText);
+                    await message.reply(messageText);
                 } else {
-                    return await message.author.send(messageText);
+                    await message.author.send(messageText);
                 }
             },
         },
@@ -374,7 +397,6 @@ export async function addSpectatedPlayerMessage(player, speaker, message, whispe
                     });
                     const cachedMessage = speaker.game.dialogCache.find((entry) => entry.messageId === message.id);
                     if (cachedMessage) cachedMessage.spectateMirrors.push({ messageId: webhookMessage.id, webhookId: webhook.id });
-                    return webhookMessage;
                 },
             },
             "spectator"

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,4 +1,4 @@
-import type { ActivitiesOptions, ActivityType, GuildMember, Message, Snowflake } from "discord.js";
+import type { ActivitiesOptions, ActivityType, GuildMember, Message, OmitPartialGroupDMChannel, Snowflake } from "discord.js";
 import type GameSettings from "./Classes/GameSettings.js";
 import type Event from "./Data/Event.js";
 import type Flag from "./Data/Flag.js";
@@ -26,6 +26,16 @@ declare global {
 		type: ActivityType;
 		url?: string;
 	}
+
+	/**
+	 * Represents a Discord message handled by Alter Ego.
+	 */
+	type AEMessage = OmitPartialGroupDMChannel<Message>;
+
+	/**
+	 * Represents a Discord object that can be messaged.
+	 */
+	type Messageable = AEMessage['channel'];
 
 	/**
 	 * A cached dialog message.
@@ -80,15 +90,15 @@ declare global {
 	}
 
 	interface IModeratorCommand extends Command {
-		execute: (game: Game, message: Message, command: string, args: string[]) => Promise<void>;
+		execute: (game: Game, message: AEMessage, command: string, args: string[]) => Promise<void>;
 	}
 
 	interface IPlayerCommand extends Command {
-		execute: (game: Game, message: Message, command: string, args: string[], player: Player) => Promise<void>;
+		execute: (game: Game, message: AEMessage, command: string, args: string[], player: Player) => Promise<void>;
 	}
 
 	interface IEligibleCommand extends Command {
-		execute: (game: Game, message: Message, command: string, args: string[]) => Promise<void>;
+		execute: (game: Game, message: AEMessage, command: string, args: string[]) => Promise<void>;
 	}
 
 	/**

--- a/global.d.ts
+++ b/global.d.ts
@@ -117,7 +117,7 @@ declare global {
 	 * Represents a queue entry for a message waiting to be sent in one of the priority queue's stack queues.
 	 */
 	interface MessageQueueEntry {
-		fire: () => Promise<Message>;
+		fire: () => Promise<void>;
 	}
 
 	/**

--- a/global.d.ts
+++ b/global.d.ts
@@ -30,12 +30,12 @@ declare global {
 	/**
 	 * Represents a Discord message handled by Alter Ego.
 	 */
-	type AEMessage = OmitPartialGroupDMChannel<Message>;
+	type UserMessage = OmitPartialGroupDMChannel<Message>;
 
 	/**
 	 * Represents a Discord object that can be messaged.
 	 */
-	type Messageable = AEMessage['channel'];
+	type Messageable = UserMessage['channel'];
 
 	/**
 	 * A cached dialog message.
@@ -90,15 +90,15 @@ declare global {
 	}
 
 	interface IModeratorCommand extends Command {
-		execute: (game: Game, message: AEMessage, command: string, args: string[]) => Promise<void>;
+		execute: (game: Game, message: UserMessage, command: string, args: string[]) => Promise<void>;
 	}
 
 	interface IPlayerCommand extends Command {
-		execute: (game: Game, message: AEMessage, command: string, args: string[], player: Player) => Promise<void>;
+		execute: (game: Game, message: UserMessage, command: string, args: string[], player: Player) => Promise<void>;
 	}
 
 	interface IEligibleCommand extends Command {
-		execute: (game: Game, message: AEMessage, command: string, args: string[]) => Promise<void>;
+		execute: (game: Game, message: UserMessage, command: string, args: string[]) => Promise<void>;
 	}
 
 	/**


### PR DESCRIPTION
I'll start this PR by apologizing for pursuing this endeavor without direction to do so, but it's my understanding that the lack of type safety for `.send()` on Discord.js standard `Message.channel` objects is a source of frustration. This PR introduces the global types, AEMessage and Messageable, to represent a message with a Messageable channel property, and an arbitrary Discord.js object that supports the `.send()` function.

This is *almost* exclusively a type change. However, there exists a single functional change in the messageHandler module: Removing the `channel.parent !== undefined` check on `addGameMechanicMessage()`, to comply with the AEMessage type. Besides this change, I'm confident that all changes introduced in this PR are simple type changes intended to ease future development.
-💾