### PR TITLE
Fix Game.js Event day-of-month trigger time check

### DIFF
--- a/Data/Game.js
+++ b/Data/Game.js
@@ -331,6 +331,7 @@ export default class Game {
 							const time = Event.parseTriggerTime(triggerTimeString);
 							if (time.valid
 								&& now.month === time.datetime.month
+								&& now.day === time.datetime.day
 								&& now.weekday === time.datetime.weekday
 								&& now.hour === time.datetime.hour
 								&& now.minute === time.datetime.minute) {


### PR DESCRIPTION
Following insights from the testing branch, this PR resolves a too-loose time equivalence check in Game.js for Event trigger time checks. Before, a trigger time may fire so long as it shares a month, weekday, hour, and minute with the current time. Crucially, this misses equivalence in the day of the month. A single added line resolves this issue.
-💾