### PR TITLE
Status Effect bugfixes

### DIFF
--- a/Classes/PrettyPrinter.js
+++ b/Classes/PrettyPrinter.js
@@ -74,7 +74,7 @@ class GameFilterPlugin {
             [
                 (value) => value instanceof Status,
                 (/** @type {Status} */ value) =>
-                    `<Status "${value.id}" lasting ${humanize(value.duration?.as('milliseconds')) || "unknown"}>`,
+                    `<Status "${value.id}" lasting ${humanize(value.remaining?.as('milliseconds')) || "unknown"}>`,
             ],
             [(value) => value instanceof Gesture, (/** @type {Gesture} */ value) => `<Gesture "${value.id}">`],
             [

--- a/Data/Actions/CureAction.js
+++ b/Data/Actions/CureAction.js
@@ -30,7 +30,7 @@ export default class CureAction extends Action {
 	performCure(status, notify = true, doCuredCondition = true, narrate = true, item) {
 		if (this.performed) return false;
 		super.perform();
-		const playerStatusIds = this.player.status.map(statusEffect => statusEffect.id);
+		const playerStatusIds = this.player.statusCollection.map(statusEffect => statusEffect.id);
 		if (!playerStatusIds.includes(status.id)) {
 			if (this.message) this.message.reply(`Specified player doesn't have that status effect.`);
 			return false;

--- a/Data/Actions/InflictAction.js
+++ b/Data/Actions/InflictAction.js
@@ -31,7 +31,7 @@ export default class InflictAction extends Action {
 	performInflict(status, notify = true, doCures = true, narrate = true, item, duration = null) {
 		if (this.performed) return false;
 		super.perform();
-		const playerStatusIds = this.player.status.map(statusEffect => statusEffect.id);
+		const playerStatusIds = this.player.statusCollection.map(statusEffect => statusEffect.id);
 		for (const overrider of status.overriders) {
 			if (playerStatusIds.includes(overrider.id)) {
 				if (this.message) this.message.reply(`Couldn't inflict status effect "${status.id}" because ${this.player.name} is already ${overrider.id}.`);

--- a/Data/Player.js
+++ b/Data/Player.js
@@ -698,7 +698,7 @@ export default class Player extends ItemContainer {
                         const cureAction = new CureAction(player.getGame(), undefined, player, player.location, true);
                         cureAction.performCure(statusInstance.nextStage, false, false, true);
                         let inflictNextStage = true;
-                        const playerStatusIds = player.status.map(statusEffect => statusEffect.id);
+                        const playerStatusIds = player.statusCollection.map(statusEffect => statusEffect.id);
                         for (const overrider of statusInstance.nextStage.overriders) {
                             if (playerStatusIds.includes(overrider.id)) {
                                 player.sendDescription(statusInstance.curedDescription, statusInstance);
@@ -741,6 +741,7 @@ export default class Player extends ItemContainer {
         // Stop the timer.
         if (statusInstance.timer !== null)
             statusInstance.timer.stop();
+        this.statusCollection.delete(status.id)
         this.#recalculateStats();
         this.statusDisplays = this.#generateStatusDisplays(true, true);
     }


### PR DESCRIPTION
This PR resolves a minor inconsistency in the Pretty Printer, three references to a deprecated property, and a sheet-breaking bug where status effects are not removed from a player's status collection after being cured.
* PrettyPrinter now references the time remaining of a status effect when truncating a status effect, rather than the status duration.
* CureAction, InflictAction, and Status Effect tick timers now gather an array of status IDs from StatusCollection, rather than the deprecated Status array
* Player.cure() now removes a cured status effect from the StatusCollection

As an aside, an odd behavior noted while hunting this bug is that Events do not appear to properly refresh status effects after game start. Once a status effect expires, Events can properly inflict and refresh the status effect once more.
-💾