### PR TITLE
commandHandler tweak

### DIFF
--- a/Modules/commandHandler.js
+++ b/Modules/commandHandler.js
@@ -32,7 +32,7 @@ export async function executeCommand(commandStr, game, message, player, callee) 
         else if (member && !game.settings.debug && member.roles.cache.has(game.guildContext.eligibleRole.id)) isEligible = true;
     }
 
-    const commandSplit = commandStr.split(" ");
+    const commandSplit = commandStr.split(/\s/).filter(arg => arg !== "");
     const commandAlias = commandSplit[0].toLocaleLowerCase();
     const args = commandSplit.slice(1);
 

--- a/Modules/commandHandler.js
+++ b/Modules/commandHandler.js
@@ -32,7 +32,7 @@ export async function executeCommand(commandStr, game, message, player, callee) 
         else if (member && !game.settings.debug && member.roles.cache.has(game.guildContext.eligibleRole.id)) isEligible = true;
     }
 
-    const commandSplit = commandStr.split(/\s/).filter(arg => arg !== "");
+    const commandSplit = commandStr.split(/[^\S\n]/).filter(arg => arg !== "");
     const commandAlias = commandSplit[0].toLocaleLowerCase();
     const args = commandSplit.slice(1);
 


### PR DESCRIPTION
Hello! This PR tweaks the commandHandler such that incoming commands are now split on *any* whitespace, rather than the standard ASCII space. Additionally, the resulting array has empty strings filtered out. This will impact the ability for commands to handle newlines, but may also ease internationalization efforts in the future, as well as ease command argument parsing.
—❄️