### PR TITLE
Bump node.js version to 24 (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:lts-slim
-ENV NODE_ENV production
+FROM node:24
+ENV NODE_ENV=production
 
 ARG image_commit
 ARG image_tag

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "url": "https://github.com/MolSnoo/Alter-Ego/issues"
   },
   "homepage": "https://github.com/MolSnoo/Alter-Ego",
+  "engines": {
+    "node": ">=24.11.0"
+  },
   "types": "dist/bot.d.ts",
   "dependencies": {
     "@types/humanize-duration": "^3.27.4",


### PR DESCRIPTION
Explicitly use node.js 24 in Dockerfile and set minimum engine version to 24.11 (LTS) in package.json