### PR TITLE
Feature/GEL-error-output-tweak

### DIFF
--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -112,10 +112,7 @@ export default class GameEntityLoader extends GameEntityManager {
 				if (error instanceof Error) errors.push(error);
 			}
 			if (errors.length > 0) {
-				if (errors.length > 15) {
-					errors = errors.slice(0, 15);
-					errors.push(new Error("Too many errors."));
-				}
+				errors = this.#trimErrors(errors);
 				resolve(errors.join('\n'));
 			}
 			else {


### PR DESCRIPTION
This PR tweaks the loadAll function of the GEL to call #trimErrors, instead of custom error slicing based only on the length of the errors array.
—💾