### PR TITLE
Feature/handle-query-strings

### DIFF
--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -526,7 +526,7 @@ export default class GameEntityLoader extends GameEntityManager {
 			return new Error(`Couldn't load room on row ${room.row}. The room ID exceeds 100 characters in length.`);
 		if (room.channel === null || room.channel === undefined)
 			return new Error(`Couldn't load room "${room.id}" on row ${room.row}. There is no corresponding channel on the server, and a channel to accommodate the room could not be automatically created.`);
-		const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|gif|webp|avif))(?:\?[^#\s]*)?$/;
+		const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
 		if (room.iconURL !== "" && !iconURLSyntax.test(room.iconURL))
 			return new Error(`Couldn't load room on row ${room.row}. The icon URL must have a .jpg, .jpeg, .png, .gif, .webp, or .avif extension.`);
 		for (const exit of room.exitCollection.values()) {

--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -526,7 +526,7 @@ export default class GameEntityLoader extends GameEntityManager {
 			return new Error(`Couldn't load room on row ${room.row}. The room ID exceeds 100 characters in length.`);
 		if (room.channel === null || room.channel === undefined)
 			return new Error(`Couldn't load room "${room.id}" on row ${room.row}. There is no corresponding channel on the server, and a channel to accommodate the room could not be automatically created.`);
-		const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|webp|avif))(?:\?[^#\s]*)?$/;
+		const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|gif|webp|avif))(?:\?[^#\s]*)?$/;
 		if (room.iconURL !== "" && !iconURLSyntax.test(room.iconURL))
 			return new Error(`Couldn't load room on row ${room.row}. The icon URL must have a .jpg, .jpeg, .png, .gif, .webp, or .avif extension.`);
 		for (const exit of room.exitCollection.values()) {

--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -526,7 +526,7 @@ export default class GameEntityLoader extends GameEntityManager {
 			return new Error(`Couldn't load room on row ${room.row}. The room ID exceeds 100 characters in length.`);
 		if (room.channel === null || room.channel === undefined)
 			return new Error(`Couldn't load room "${room.id}" on row ${room.row}. There is no corresponding channel on the server, and a channel to accommodate the room could not be automatically created.`);
-		const iconURLSyntax = RegExp('(http(s?)://.*?.(jpg|jpeg|png|gif|webp|avif))$');
+		const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|webp|avif))(?:\?[^#\s]*)?$/;
 		if (room.iconURL !== "" && !iconURLSyntax.test(room.iconURL))
 			return new Error(`Couldn't load room on row ${room.row}. The icon URL must have a .jpg, .jpeg, .png, .gif, .webp, or .avif extension.`);
 		for (const exit of room.exitCollection.values()) {
@@ -1799,7 +1799,7 @@ export default class GameEntityLoader extends GameEntityManager {
 	async checkPlayer(player) {
 		if (!player.isNPC && (player.id === "" || player.id === null || player.id === undefined))
 			return new Error(`Couldn't load player on row ${player.row}. No Discord ID was given.`);
-		const iconURLSyntax = RegExp('(http(s?)://.*?.(jpg|jpeg|png|webp|avif))$');
+		const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|webp|avif))(?:\?[^#\s]*)?$/;
 		if (player.isNPC && (player.id === "" || player.id === null || player.id === undefined || !iconURLSyntax.test(player.id)))
 			return new Error(`Couldn't load player on row ${player.row}. The Discord ID for an NPC must be a URL with a .jpg, .jpeg, .png, .webp, or .avif extension.`);
 		if (!player.isNPC && (player.member === null || player.member === undefined))

--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -1799,7 +1799,7 @@ export default class GameEntityLoader extends GameEntityManager {
 	async checkPlayer(player) {
 		if (!player.isNPC && (player.id === "" || player.id === null || player.id === undefined))
 			return new Error(`Couldn't load player on row ${player.row}. No Discord ID was given.`);
-		const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|webp|avif))(?:\?[^#\s]*)?$/;
+		const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
 		if (player.isNPC && (player.id === "" || player.id === null || player.id === undefined || !iconURLSyntax.test(player.id)))
 			return new Error(`Couldn't load player on row ${player.row}. The Discord ID for an NPC must be a URL with a .jpg, .jpeg, .png, .webp, or .avif extension.`);
 		if (!player.isNPC && (player.member === null || player.member === undefined))

--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -1799,7 +1799,7 @@ export default class GameEntityLoader extends GameEntityManager {
 	async checkPlayer(player) {
 		if (!player.isNPC && (player.id === "" || player.id === null || player.id === undefined))
 			return new Error(`Couldn't load player on row ${player.row}. No Discord ID was given.`);
-		const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
+		const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|webp|avif))(\?[^\s]*)?$/;
 		if (player.isNPC && (player.id === "" || player.id === null || player.id === undefined || !iconURLSyntax.test(player.id)))
 			return new Error(`Couldn't load player on row ${player.row}. The Discord ID for an NPC must be a URL with a .jpg, .jpeg, .png, .webp, or .avif extension.`);
 		if (!player.isNPC && (player.member === null || player.member === undefined))

--- a/Commands/setdefaultroomicon_bot.js
+++ b/Commands/setdefaultroomicon_bot.js
@@ -35,7 +35,7 @@ export async function execute(game, command, args, player, callee) {
     const cmdString = command + " " + args.join(" ");
 
     const input = args.join(" ").replace(/(?<=http(s?))@(?=.*?(jpg|jpeg|png|gif|webp|avif))/g, ':').replace(/(?<=http(s?):.*?)\\(?=.*?(jpg|jpeg|png|gif|webp|avif))/g, '/');
-    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\\?.*)?$/;
+    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
     if (!iconURLSyntax.test(input) && input !== "") return game.communicationHandler.sendToCommandChannel(`Error: Couldn't execute command "${cmdString}". The display icon must be a URL with a .jpg, .jpeg, .png, .gif, .webp, or .avif extension.`);
 
     game.settings.defaultRoomIconURL = input;

--- a/Commands/setdefaultroomicon_bot.js
+++ b/Commands/setdefaultroomicon_bot.js
@@ -35,7 +35,7 @@ export async function execute(game, command, args, player, callee) {
     const cmdString = command + " " + args.join(" ");
 
     const input = args.join(" ").replace(/(?<=http(s?))@(?=.*?(jpg|jpeg|png|gif|webp|avif))/g, ':').replace(/(?<=http(s?):.*?)\\(?=.*?(jpg|jpeg|png|gif|webp|avif))/g, '/');
-    const iconURLSyntax = RegExp('(http(s?)://.*?.(jpg|jpeg|png|gif|webp|avif))$');
+    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\\?.*)?$/;
     if (!iconURLSyntax.test(input) && input !== "") return game.communicationHandler.sendToCommandChannel(`Error: Couldn't execute command "${cmdString}". The display icon must be a URL with a .jpg, .jpeg, .png, .gif, .webp, or .avif extension.`);
 
     game.settings.defaultRoomIconURL = input;

--- a/Commands/setdefaultroomicon_bot.js
+++ b/Commands/setdefaultroomicon_bot.js
@@ -35,7 +35,7 @@ export async function execute(game, command, args, player, callee) {
     const cmdString = command + " " + args.join(" ");
 
     const input = args.join(" ").replace(/(?<=http(s?))@(?=.*?(jpg|jpeg|png|gif|webp|avif))/g, ':').replace(/(?<=http(s?):.*?)\\(?=.*?(jpg|jpeg|png|gif|webp|avif))/g, '/');
-    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
+    const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
     if (!iconURLSyntax.test(input) && input !== "") return game.communicationHandler.sendToCommandChannel(`Error: Couldn't execute command "${cmdString}". The display icon must be a URL with a .jpg, .jpeg, .png, .gif, .webp, or .avif extension.`);
 
     game.settings.defaultRoomIconURL = input;

--- a/Commands/setdefaultroomicon_moderator.js
+++ b/Commands/setdefaultroomicon_moderator.js
@@ -30,7 +30,7 @@ export function usage(settings) {
  * @param {string[]} args - A list of arguments passed to the command as individual words.
  */
 export async function execute(game, message, command, args) {
-    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\\?.*)?$/;
+    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
     let input = args.join(" ");
     if (input.length === 0) {
         if (message.attachments.size !== 0)

--- a/Commands/setdefaultroomicon_moderator.js
+++ b/Commands/setdefaultroomicon_moderator.js
@@ -30,7 +30,7 @@ export function usage(settings) {
  * @param {string[]} args - A list of arguments passed to the command as individual words.
  */
 export async function execute(game, message, command, args) {
-    const iconURLSyntax = RegExp('(http(s?)://.*?\\.(jpg|jpeg|png|gif|webp|avif))(\\?.*)?$');
+    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\\?.*)?$/;
     let input = args.join(" ");
     if (input.length === 0) {
         if (message.attachments.size !== 0)

--- a/Commands/setdefaultroomicon_moderator.js
+++ b/Commands/setdefaultroomicon_moderator.js
@@ -30,7 +30,7 @@ export function usage(settings) {
  * @param {string[]} args - A list of arguments passed to the command as individual words.
  */
 export async function execute(game, message, command, args) {
-    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
+    const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
     let input = args.join(" ");
     if (input.length === 0) {
         if (message.attachments.size !== 0)

--- a/Commands/setdisplayicon_bot.js
+++ b/Commands/setdisplayicon_bot.js
@@ -50,7 +50,7 @@ export async function execute(game, command, args, player, callee) {
     args.splice(0, 1);
 
     let input = args.join(" ").replace(/(?<=http(s?))@(?=.*?(jpg|jpeg|png|webp|avif))/g, ':').replace(/(?<=http(s?):.*?)\\(?=.*?(jpg|jpeg|png|webp|avif))/g, '/');
-    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|webp|avif))(\\?.*)?$/;
+    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|webp|avif))(\?[^\s]*)?$/;
     if (input === "") {
         if (player.isNPC) input = player.id;
         else input = null;

--- a/Commands/setdisplayicon_bot.js
+++ b/Commands/setdisplayicon_bot.js
@@ -50,7 +50,7 @@ export async function execute(game, command, args, player, callee) {
     args.splice(0, 1);
 
     let input = args.join(" ").replace(/(?<=http(s?))@(?=.*?(jpg|jpeg|png|webp|avif))/g, ':').replace(/(?<=http(s?):.*?)\\(?=.*?(jpg|jpeg|png|webp|avif))/g, '/');
-    const iconURLSyntax = RegExp('(http(s?)://.*?.(jpg|jpeg|png|webp|avif))$');
+    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\\?.*)?$/;
     if (input === "") {
         if (player.isNPC) input = player.id;
         else input = null;

--- a/Commands/setdisplayicon_bot.js
+++ b/Commands/setdisplayicon_bot.js
@@ -50,7 +50,7 @@ export async function execute(game, command, args, player, callee) {
     args.splice(0, 1);
 
     let input = args.join(" ").replace(/(?<=http(s?))@(?=.*?(jpg|jpeg|png|webp|avif))/g, ':').replace(/(?<=http(s?):.*?)\\(?=.*?(jpg|jpeg|png|webp|avif))/g, '/');
-    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|webp|avif))(\?[^\s]*)?$/;
+    const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|webp|avif))(\?[^\s]*)?$/;
     if (input === "") {
         if (player.isNPC) input = player.id;
         else input = null;

--- a/Commands/setdisplayicon_bot.js
+++ b/Commands/setdisplayicon_bot.js
@@ -50,7 +50,7 @@ export async function execute(game, command, args, player, callee) {
     args.splice(0, 1);
 
     let input = args.join(" ").replace(/(?<=http(s?))@(?=.*?(jpg|jpeg|png|webp|avif))/g, ':').replace(/(?<=http(s?):.*?)\\(?=.*?(jpg|jpeg|png|webp|avif))/g, '/');
-    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\\?.*)?$/;
+    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|webp|avif))(\\?.*)?$/;
     if (input === "") {
         if (player.isNPC) input = player.id;
         else input = null;

--- a/Commands/setdisplayicon_moderator.js
+++ b/Commands/setdisplayicon_moderator.js
@@ -39,7 +39,7 @@ export async function execute(game, message, command, args) {
     if (player === undefined) return game.communicationHandler.reply(message, `Player "${args[0]}" not found.`);
     args.splice(0, 1);
 
-    const iconURLSyntax = RegExp('(http(s?)://.*?.(jpg|jpeg|png|webp|avif))$');
+    const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|webp|avif))(?:\?[^#\s]*)?$/;
     let input = args.join(" ");
     if (input === "") {
         if (player.isNPC) input = player.id;

--- a/Commands/setdisplayicon_moderator.js
+++ b/Commands/setdisplayicon_moderator.js
@@ -39,7 +39,7 @@ export async function execute(game, message, command, args) {
     if (player === undefined) return game.communicationHandler.reply(message, `Player "${args[0]}" not found.`);
     args.splice(0, 1);
 
-    const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|webp|avif))(?:\?[^#\s]*)?$/;
+    const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|webp|avif))(\?[^\s]*)?$/;
     let input = args.join(" ");
     if (input === "") {
         if (player.isNPC) input = player.id;

--- a/Commands/setroomicon_bot.js
+++ b/Commands/setroomicon_bot.js
@@ -47,7 +47,7 @@ export async function execute(game, command, args, player, callee) {
     if (room === undefined)
         game.communicationHandler.sendToCommandChannel(`Error: Couldn't execute command "${cmdString}". Room "${input}" not found.`);
 
-    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
+    const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
     input = input.replace(iconURLSyntax, '$1').replace(/(?<=http(s?))@(?=.*?(jpg|jpeg|png|gif|webp|avif))/g, ':').replace(/(?<=http(s?):.*?)\\(?=.*?(jpg|jpeg|png|gif|webp|avif))/g, '/');
     if (!iconURLSyntax.test(input)) return game.communicationHandler.sendToCommandChannel(`Error: Couldn't execute command "${cmdString}". The display icon must be a URL with a .jpg, .jpeg, .png, .gif, .webp, or .avif extension.`);
 

--- a/Commands/setroomicon_bot.js
+++ b/Commands/setroomicon_bot.js
@@ -47,7 +47,7 @@ export async function execute(game, command, args, player, callee) {
     if (room === undefined)
         game.communicationHandler.sendToCommandChannel(`Error: Couldn't execute command "${cmdString}". Room "${input}" not found.`);
 
-    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\\?.*)?$/;
+    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
     input = input.replace(iconURLSyntax, '$1').replace(/(?<=http(s?))@(?=.*?(jpg|jpeg|png|gif|webp|avif))/g, ':').replace(/(?<=http(s?):.*?)\\(?=.*?(jpg|jpeg|png|gif|webp|avif))/g, '/');
     if (!iconURLSyntax.test(input)) return game.communicationHandler.sendToCommandChannel(`Error: Couldn't execute command "${cmdString}". The display icon must be a URL with a .jpg, .jpeg, .png, .gif, .webp, or .avif extension.`);
 

--- a/Commands/setroomicon_bot.js
+++ b/Commands/setroomicon_bot.js
@@ -47,7 +47,7 @@ export async function execute(game, command, args, player, callee) {
     if (room === undefined)
         game.communicationHandler.sendToCommandChannel(`Error: Couldn't execute command "${cmdString}". Room "${input}" not found.`);
 
-    const iconURLSyntax = RegExp('(http(s?)://.*?.(jpg|jpeg|png|gif|webp|avif))$');
+    const iconURLSyntax = /(http(s?):\/\/.*?\\.(jpg|jpeg|png|gif|webp|avif))(\\?.*)?$/;
     input = input.replace(iconURLSyntax, '$1').replace(/(?<=http(s?))@(?=.*?(jpg|jpeg|png|gif|webp|avif))/g, ':').replace(/(?<=http(s?):.*?)\\(?=.*?(jpg|jpeg|png|gif|webp|avif))/g, '/');
     if (!iconURLSyntax.test(input)) return game.communicationHandler.sendToCommandChannel(`Error: Couldn't execute command "${cmdString}". The display icon must be a URL with a .jpg, .jpeg, .png, .gif, .webp, or .avif extension.`);
 

--- a/Commands/setroomicon_moderator.js
+++ b/Commands/setroomicon_moderator.js
@@ -42,7 +42,7 @@ export async function execute(game, message, command, args) {
     }
     if (room === undefined) return game.communicationHandler.reply(message, `Couldn't find room "${input}".`);
 
-    const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|webp|avif))(?:\?[^#\s]*)?$/;
+    const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|gif|webp|avif))(?:\?[^#\s]*)?$/;
     input = input.replace(iconURLSyntax, '$1');
     if (input.length === 0) {
         if (message.attachments.size !== 0)

--- a/Commands/setroomicon_moderator.js
+++ b/Commands/setroomicon_moderator.js
@@ -42,7 +42,7 @@ export async function execute(game, message, command, args) {
     }
     if (room === undefined) return game.communicationHandler.reply(message, `Couldn't find room "${input}".`);
 
-    const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|gif|webp|avif))(?:\?[^#\s]*)?$/;
+    const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|gif|webp|avif))(\?[^\s]*)?$/;
     input = input.replace(iconURLSyntax, '$1');
     if (input.length === 0) {
         if (message.attachments.size !== 0)

--- a/Commands/setroomicon_moderator.js
+++ b/Commands/setroomicon_moderator.js
@@ -42,7 +42,7 @@ export async function execute(game, message, command, args) {
     }
     if (room === undefined) return game.communicationHandler.reply(message, `Couldn't find room "${input}".`);
 
-    const iconURLSyntax = RegExp('(http(s?)://.*?\\.(jpg|jpeg|png|gif|webp|avif))(\\?.*)?$');
+    const iconURLSyntax = /(http(s?):\/\/.*?\.(jpg|jpeg|png|webp|avif))(?:\?[^#\s]*)?$/;
     input = input.replace(iconURLSyntax, '$1');
     if (input.length === 0) {
         if (message.attachments.size !== 0)


### PR DESCRIPTION
This PR implements query string support for image URLs by adding an optional non-capturing group that begins with ? and ends at whitespace or #. The format of the regex URL syntax was also changed, and the dot before extensions was replaced with a dot literal.
—💾