### PR TITLE
Fix status infliction

### DIFF
--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -1573,20 +1573,7 @@ export default class GameEntityLoader extends GameEntityManager {
 				this.updateStatusEffectReferences(status);
 			}
 			this.game.statusEffectsCollection.forEach(status => {
-				status.overridersStrings.forEach((overriderString, i) => {
-					const overrider = this.game.entityFinder.getStatusEffect(overriderString);
-					if (overrider) status.overriders[i] = overrider;
-				});
-				status.curesStrings.forEach((curesString, i) => {
-					const cure = this.game.entityFinder.getStatusEffect(curesString);
-					if (cure) status.cures[i] = cure;
-				});
-				const nextStage = this.game.entityFinder.getStatusEffect(status.nextStageId);
-				if (nextStage) status.setNextStage(nextStage);
-				const duplicatedStatus = this.game.entityFinder.getStatusEffect(status.duplicatedStatusId);
-				if (duplicatedStatus) status.setDuplicatedStatus(duplicatedStatus);
-				const curedCondition = this.game.entityFinder.getStatusEffect(status.curedConditionId);
-				if (curedCondition) status.setCuredCondition(curedCondition);
+				Status.postProcess(status);
 				if (doErrorChecking) {
 					const error = this.checkStatusEffect(status);
 					if (error instanceof Error) errors.push(error);

--- a/Data/Player.js
+++ b/Data/Player.js
@@ -691,6 +691,7 @@ export default class Player extends ItemContainer {
      */
     inflict(status, duration = null) {
         const statusInstance = new Status(status.id, status.duration, status.fatal, status.visible, status.overridersStrings, status.curesStrings, status.nextStageId, status.duplicatedStatusId, status.curedConditionId, status.statModifiers, status.behaviorAttributes, status.inflictedDescription, status.curedDescription, status.row, this.getGame());
+        Status.postProcess(statusInstance);
 
         // Apply the duration, if applicable.
         if (statusInstance.duration) {
@@ -706,8 +707,6 @@ export default class Player extends ItemContainer {
 
                 if (statusInstance.remaining.as('milliseconds') <= 0) {
                     if (statusInstance.nextStage) {
-                        const cureAction = new CureAction(player.getGame(), undefined, player, player.location, true);
-                        cureAction.performCure(statusInstance.nextStage, false, false, true);
                         let inflictNextStage = true;
                         const playerStatusIds = player.statusCollection.map(statusEffect => statusEffect.id);
                         for (const overrider of statusInstance.nextStage.overriders) {
@@ -718,6 +717,10 @@ export default class Player extends ItemContainer {
                             }
                         }
                         if (inflictNextStage) {
+                            const cureNextAction = new CureAction(player.getGame(), undefined, player, player.location, true);
+                            cureNextAction.performCure(statusInstance.nextStage, false, false, true);
+                            const cureAction = new CureAction(player.getGame(), undefined, player, player.location, true);
+                            cureAction.performCure(statusInstance, true, true, true);
                             const nextStageAction = new InflictAction(player.getGame(), undefined, player, player.location, true);
                             nextStageAction.performInflict(statusInstance.nextStage, true, false, true);
                         }

--- a/Data/Status.js
+++ b/Data/Status.js
@@ -224,4 +224,25 @@ export default class Status extends GameEntity {
     static generateValidId(id) {
         return id.toLowerCase().trim();
     }
+
+    /**
+     * Perform post-initialization processing on a status effect.
+     * @param {Status} status
+     */
+    static postProcess(status) {
+        status.overridersStrings.forEach((overriderString, i) => {
+            const overrider = status.getGame().entityFinder.getStatusEffect(overriderString);
+            if (overrider) status.overriders[i] = overrider;
+        });
+        status.curesStrings.forEach((curesString, i) => {
+            const cure = status.getGame().entityFinder.getStatusEffect(curesString);
+            if (cure) status.cures[i] = cure;
+        });
+        const nextStage = status.getGame().entityFinder.getStatusEffect(status.nextStageId);
+        if (nextStage) status.setNextStage(nextStage);
+        const duplicatedStatus = status.getGame().entityFinder.getStatusEffect(status.duplicatedStatusId);
+        if (duplicatedStatus) status.setDuplicatedStatus(duplicatedStatus);
+        const curedCondition = status.getGame().entityFinder.getStatusEffect(status.curedConditionId);
+        if (curedCondition) status.setCuredCondition(curedCondition);
+    }
 }


### PR DESCRIPTION
Hello! This PR fixes the broken overriders, cures, nextStage, duplication behavior, and curedCondition behavior of Status Effects inflicted using `Player.inflict()`. This is accomplished by moving the GEL Status Effect post-processing logic into a static function of Status, which both the GEL and `Player.inflict()` now call.

Additionally, cureAction() on nextStage is now only called if nextStage is to be inflicted. Additionally, the status preceding nextStage is now cured before inflicting nextStage, to prevent sheet-breaking timer underruns.
—❄️