### PR TITLE
Feature/refactor-type-imports

### DIFF
--- a/Classes/BotCommand.js
+++ b/Classes/BotCommand.js
@@ -1,10 +1,10 @@
-/** @typedef {import("../Data/Event.js").default} Event */
-/** @typedef {import("../Data/Flag.js").default} Flag */
-/** @typedef {import("../Data/Game.js").default} Game */
-/** @typedef {import("./GameSettings.js").default} GameSettings */
-/** @typedef {import("../Data/InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../Data/Player.js").default} Player */
-/** @typedef {import("../Data/Puzzle.js").default} Puzzle */
+/** @import Event from "../Data/Event.js" */
+/** @import Flag from "../Data/Flag.js" */
+/** @import Game from "../Data/Game.js" */
+/** @import GameSettings from "./GameSettings.js" */
+/** @import InventoryItem from "../Data/InventoryItem.js" */
+/** @import Player from "../Data/Player.js" */
+/** @import Puzzle from "../Data/Puzzle.js" */
 
 /**
  * @class BotCommand

--- a/Classes/BotContext.js
+++ b/Classes/BotContext.js
@@ -1,11 +1,11 @@
 import { ActivityType, Collection } from "discord.js";
 import PrettyPrinter from "./PrettyPrinter.js";
 
-/** @typedef {import("../Data/Game.js").default} Game */
-/** @typedef {import("./BotCommand.js").default} BotCommand */
-/** @typedef {import("./ModeratorCommand.js").default} ModeratorCommand */
-/** @typedef {import("./PlayerCommand.js").default} PlayerCommand */
-/** @typedef {import("./EligibleCommand.js").default} EligibleCommand */
+/** @import Game from "../Data/Game.js" */
+/** @import BotCommand from "./BotCommand.js" */
+/** @import ModeratorCommand from "./ModeratorCommand.js" */
+/** @import PlayerCommand from "./PlayerCommand.js" */
+/** @import EligibleCommand from "./EligibleCommand.js" */
 /** @typedef {(import("discord.js").Client)} Client */
 
 /**

--- a/Classes/BotContext.js
+++ b/Classes/BotContext.js
@@ -6,7 +6,7 @@ import PrettyPrinter from "./PrettyPrinter.js";
 /** @import ModeratorCommand from "./ModeratorCommand.js" */
 /** @import PlayerCommand from "./PlayerCommand.js" */
 /** @import EligibleCommand from "./EligibleCommand.js" */
-/** @typedef {(import("discord.js").Client)} Client */
+/** @import { Client } from "discord.js" */
 
 /**
  * @class BotContext

--- a/Classes/EligibleCommand.js
+++ b/Classes/EligibleCommand.js
@@ -1,5 +1,5 @@
-/** @typedef {import("../Data/Game.js").default} Game */
-/** @typedef {import("./GameSettings.js").default} GameSettings */
+/** @import Game from "../Data/Game.js" */
+/** @import GameSettings from "./GameSettings.js" */
 
 /**
  * @class EligibleCommand

--- a/Classes/GameCommunicationHandler.js
+++ b/Classes/GameCommunicationHandler.js
@@ -6,12 +6,12 @@ import { parseDescription } from "../Modules/parser.js";
 import { capitalizeFirstLetter } from "../Modules/helpers.js";
 import { Attachment, Collection, TextChannel } from "discord.js";
 
-/** @typedef {import("../Data/Dialog.js").default} Dialog */
-/** @typedef {import("../Data/Game.js").default} Game */
-/** @typedef {import("../Data/GameEntity.js").default} GameEntity */
-/** @typedef {import("../Data/Narration.js").default} Narration */
-/** @typedef {import("../Data/Player.js").default} Player */
-/** @typedef {import("../Data/Whisper.js").default} Whisper */
+/** @import Dialog from "../Data/Dialog.js" */
+/** @import Game from "../Data/Game.js" */
+/** @import GameEntity from "../Data/GameEntity.js" */
+/** @import Narration from "../Data/Narration.js" */
+/** @import Player from "../Data/Player.js" */
+/** @import Whisper from "../Data/Whisper.js" */
 /** @typedef {import("discord.js").Snowflake} Snowflake */
 
 /**

--- a/Classes/GameCommunicationHandler.js
+++ b/Classes/GameCommunicationHandler.js
@@ -11,8 +11,7 @@ import { Attachment, Collection, TextChannel } from "discord.js";
 /** @import GameEntity from "../Data/GameEntity.js" */
 /** @import Narration from "../Data/Narration.js" */
 /** @import Player from "../Data/Player.js" */
-/** @import Whisper from "../Data/Whisper.js" */
-/** @typedef {import("discord.js").Snowflake} Snowflake */
+/** @import { Snowflake } from "discord.js" */
 
 /**
  * @class GameCommunicationHandler

--- a/Classes/GameEntityManager.js
+++ b/Classes/GameEntityManager.js
@@ -2,14 +2,14 @@ import Room from "../Data/Room.js";
 import Whisper from "../Data/Whisper.js";
 import { ChannelType, TextChannel } from "discord.js";
 
-/** @typedef {import("../Data/Event.js").default} Event */
-/** @typedef {import("../Data/Fixture.js").default} Fixture */
-/** @typedef {import("../Data/Flag.js").default} Flag */
-/** @typedef {import("../Data/Game.js").default} Game */
-/** @typedef {import("../Data/Player.js").default} Player */
-/** @typedef {import("../Data/Prefab.js").default} Prefab */
-/** @typedef {import("../Data/Puzzle.js").default} Puzzle */
-/** @typedef {import("../Data/Status.js").default} Status */
+/** @import Event from "../Data/Event.js" */
+/** @import Fixture from "../Data/Fixture.js" */
+/** @import Flag from "../Data/Flag.js" */
+/** @import Game from "../Data/Game.js" */
+/** @import Player from "../Data/Player.js" */
+/** @import Prefab from "../Data/Prefab.js" */
+/** @import Puzzle from "../Data/Puzzle.js" */
+/** @import Status from "../Data/Status.js" */
 
 /**
  * @class GameEntityManager

--- a/Classes/GameEntitySaver.js
+++ b/Classes/GameEntitySaver.js
@@ -1,7 +1,7 @@
 import demodata from "../Defaults/default_demodata.json" with { type: 'json' };
 import { batchUpdateSheetValues } from "../Modules/sheets.js";
 
-/** @typedef {import("../Data/Game.js").default} Game */
+/** @import Game from "../Data/Game.js" */
 
 /**
  * @class GameEntityLoader

--- a/Classes/GameLogHandler.js
+++ b/Classes/GameLogHandler.js
@@ -9,15 +9,15 @@ import Room from "../Data/Room.js";
 import RoomItem from "../Data/RoomItem.js";
 import { generateListString } from "../Modules/helpers.js";
 
-/** @typedef {import("../Data/EquipmentSlot.js").default} EquipmentSlot */
-/** @typedef {import("../Data/Flag.js").default} Flag */
-/** @typedef {import("../Data/Game.js").default} Game */
-/** @typedef {import("../Data/Gesture.js").default} Gesture */
-/** @typedef {import("../Data/Event.js").default} Event */
-/** @typedef {import("../Data/HidingSpot.js").default} HidingSpot */
-/** @typedef {import("../Data/ItemContainer.js").default} ItemContainer */
-/** @typedef {import("../Data/Status.js").default} Status */
-/** @typedef {import("../Data/Whisper.js").default} Whisper */
+/** @import EquipmentSlot from "../Data/EquipmentSlot.js" */
+/** @import Flag from "../Data/Flag.js" */
+/** @import Game from "../Data/Game.js" */
+/** @import Gesture from "../Data/Gesture.js" */
+/** @import Event from "../Data/Event.js" */
+/** @import HidingSpot from "../Data/HidingSpot.js" */
+/** @import ItemContainer from "../Data/ItemContainer.js" */
+/** @import Status from "../Data/Status.js" */
+/** @import Whisper from "../Data/Whisper.js" */
 
 /**
  * @class GameLogHandler

--- a/Classes/GameNarrationHandler.js
+++ b/Classes/GameNarrationHandler.js
@@ -24,7 +24,7 @@ import { generateListString } from "../Modules/helpers.js";
 /** @import ItemInstance from "../Data/ItemInstance.js" */
 /** @import Status from "../Data/Status.js" */
 /** @import Whisper from "../Data/Whisper.js" */
-/** @typedef {import("discord.js").GuildMember} GuildMember */
+/** @import { GuildMember } from "discord.js" */
 
 /**
  * @class GameNarrationHandler

--- a/Classes/GameNarrationHandler.js
+++ b/Classes/GameNarrationHandler.js
@@ -9,21 +9,21 @@ import { MessageDisplayType } from "../Modules/enums.js";
 import { parseDescription } from "../Modules/parser.js";
 import { generateListString } from "../Modules/helpers.js";
 
-/** @typedef {import("../Data/Action.js").default} Action */
-/** @typedef {import("../Data/Dialog.js").default} Dialog */
-/** @typedef {import("../Data/Exit.js").default} Exit */
-/** @typedef {import("../Data/Game.js").default} Game */
-/** @typedef {import("../Data/Gesture.js").default} Gesture */
-/** @typedef {import("../Data/Player.js").default} Player */
-/** @typedef {import("../Data/Puzzle.js").default} Puzzle */
-/** @typedef {import("../Data/Prefab.js").default} Prefab */
-/** @typedef {import("../Data/Recipe.js").default} Recipe */
-/** @typedef {import("../Data/Event.js").default} Event */
-/** @typedef {import("../Data/HidingSpot.js").default} HidingSpot */
-/** @typedef {import("../Data/InventorySlot.js").default} InventorySlot */
-/** @typedef {import("../Data/ItemInstance.js").default} ItemInstance */
-/** @typedef {import("../Data/Status.js").default} Status */
-/** @typedef {import("../Data/Whisper.js").default} Whisper */
+/** @import Action from "../Data/Action.js" */
+/** @import Dialog from "../Data/Dialog.js" */
+/** @import Exit from "../Data/Exit.js" */
+/** @import Game from "../Data/Game.js" */
+/** @import Gesture from "../Data/Gesture.js" */
+/** @import Player from "../Data/Player.js" */
+/** @import Puzzle from "../Data/Puzzle.js" */
+/** @import Prefab from "../Data/Prefab.js" */
+/** @import Recipe from "../Data/Recipe.js" */
+/** @import Event from "../Data/Event.js" */
+/** @import HidingSpot from "../Data/HidingSpot.js" */
+/** @import InventorySlot from "../Data/InventorySlot.js" */
+/** @import ItemInstance from "../Data/ItemInstance.js" */
+/** @import Status from "../Data/Status.js" */
+/** @import Whisper from "../Data/Whisper.js" */
 /** @typedef {import("discord.js").GuildMember} GuildMember */
 
 /**

--- a/Classes/GameNotificationGenerator.js
+++ b/Classes/GameNotificationGenerator.js
@@ -1,14 +1,14 @@
 import { capitalizeFirstLetter, endsWithPunctuation } from "../Modules/helpers.js";
 
-/** @typedef {import("../Data/Dialog.js").default} Dialog */
-/** @typedef {import("../Data/Fixture.js").default} Fixture */
-/** @typedef {import("../Data/Game.js").default} Game */
-/** @typedef {import("../Data/Player.js").default} Player */
-/** @typedef {import("../Data/Exit.js").default} Exit */
-/** @typedef {import("../Data/ItemInstance.js").default} ItemInstance */
-/** @typedef {import("../Data/Puzzle.js").default} Puzzle */
-/** @typedef {import("../Data/Recipe.js").default} Recipe */
-/** @typedef {import("../Data/Room.js").default} Room */
+/** @import Dialog from "../Data/Dialog.js" */
+/** @import Fixture from "../Data/Fixture.js" */
+/** @import Game from "../Data/Game.js" */
+/** @import Player from "../Data/Player.js" */
+/** @import Exit from "../Data/Exit.js" */
+/** @import ItemInstance from "../Data/ItemInstance.js" */
+/** @import Puzzle from "../Data/Puzzle.js" */
+/** @import Recipe from "../Data/Recipe.js" */
+/** @import Room from "../Data/Room.js" */
 
 /**
  * @class GameNotificationGenerator

--- a/Classes/GuildContext.js
+++ b/Classes/GuildContext.js
@@ -1,6 +1,6 @@
-/** @typedef {import("discord.js").Guild} Guild */
-/** @typedef {import("discord.js").Role} Role */
-/** @typedef {import("discord.js").TextChannel} TextChannel */
+/** @import { Guild } from "discord.js" */
+/** @import { Role } from "discord.js" */
+/** @import { TextChannel } from "discord.js" */
 
 /**
  * @class GuildContext

--- a/Classes/ModeratorCommand.js
+++ b/Classes/ModeratorCommand.js
@@ -1,5 +1,5 @@
-/** @typedef {import("../Data/Game.js").default} Game */
-/** @typedef {import("./GameSettings.js").default} GameSettings */
+/** @import Game from "../Data/Game.js" */
+/** @import GameSettings from "./GameSettings.js" */
 
 /**
  * @class ModeratorCommand

--- a/Classes/PlayerCommand.js
+++ b/Classes/PlayerCommand.js
@@ -1,6 +1,6 @@
-/** @typedef {import("../Data/Game.js").default} Game */
-/** @typedef {import("../Data/Player.js").default} Player */
-/** @typedef {import("./GameSettings.js").default} GameSettings */
+/** @import Game from "../Data/Game.js" */
+/** @import Player from "../Data/Player.js" */
+/** @import GameSettings from "./GameSettings.js" */
 
 /**
  * @class PlayerCommand

--- a/Classes/PrettyPrinter.js
+++ b/Classes/PrettyPrinter.js
@@ -9,11 +9,9 @@ import Player from "../Data/Player.js";
 import Room from "../Data/Room.js";
 import BotContext from "./BotContext.js";
 
-/** @typedef {import('pretty-format').NewPlugin} Plugin */
-/** @typedef {Plugin['test']} Test */
-/** @typedef {Plugin['serialize']} Serialize */
+/** @import { NewPlugin } from 'pretty-format' */
 
-/** @type {Plugin} */
+/** @type {NewPlugin} */
 class GameFilterPlugin {
     /**
      * List of formatters used by the SimpleFilterPlugin.
@@ -110,14 +108,14 @@ class GameFilterPlugin {
         ];
     }
 
-    /** @type {Test} */
+    /** @type {NewPlugin["test"]} */
     test(value) {
         if (value === null || typeof value !== "object") return false;
         if (this.processing.has(value)) return false;
         return this.constructors.has(value.constructor?.name);
     }
 
-    /** @type {Serialize} */
+    /** @type {NewPlugin["serialize"]} */
     serialize(value, config, indentation, depth, refs, printer) {
         for (const [tester, formatter] of this.formatters) {
             if (tester(value)) return formatter(value, config, indentation, depth, refs, printer);
@@ -130,7 +128,7 @@ class GameFilterPlugin {
 export default class PrettyPrinter {
     /**
      * Game filtering filter plugin for prettyString
-     * @type {Plugin}
+     * @type {NewPlugin}
      */
     gameFilterPlugin;
 

--- a/Commands/addplayer_moderator.js
+++ b/Commands/addplayer_moderator.js
@@ -3,8 +3,8 @@ import { appendRowsToSheet } from '../Modules/sheets.js';
 import { Collection } from 'discord.js';
 import {loadPlayerDefaults} from "../Modules/settingsLoader.ts";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/clean_moderator.js
+++ b/Commands/clean_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/craft_moderator.js
+++ b/Commands/craft_moderator.js
@@ -1,9 +1,9 @@
 import CraftAction from '../Data/Actions/CraftAction.js';
 import { itemIdentifierMatches } from '../Modules/matchers.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/InventoryItem.js').default} InventoryItem */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import InventoryItem from '../Data/InventoryItem.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/craft_player.js
+++ b/Commands/craft_player.js
@@ -1,10 +1,10 @@
 import CraftAction from '../Data/Actions/CraftAction.js';
 import { itemNameMatches } from '../Modules/matchers.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
-/** @typedef {import('../Data/InventoryItem.js').default} InventoryItem */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
+/** @import InventoryItem from '../Data/InventoryItem.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/createroomcategory_moderator.js
+++ b/Commands/createroomcategory_moderator.js
@@ -1,7 +1,7 @@
 import { registerRoomCategory, createCategory } from '../Modules/serverManager.ts';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/dead_moderator.js
+++ b/Commands/dead_moderator.js
@@ -1,5 +1,5 @@
-﻿/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+﻿/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 /** @type {CommandConfig} */
 export const config = {
     name: "dead_moderator",

--- a/Commands/delete_moderator.js
+++ b/Commands/delete_moderator.js
@@ -1,7 +1,7 @@
 ﻿import { ChannelType } from 'discord.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 /** @type {CommandConfig} */
 export const config = {
     name: "delete_moderator",

--- a/Commands/destroy_bot.js
+++ b/Commands/destroy_bot.js
@@ -5,10 +5,10 @@ import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
 import { itemIdentifierMatches } from "../Modules/matchers.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Player.js').default} Player */
-/** @typedef {import('../Data/InventoryItem.js').default} InventoryItem */
-/** @typedef {import('../Data/InventorySlot.js').default} InventorySlot */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Player from '../Data/Player.js' */
+/** @import InventoryItem from '../Data/InventoryItem.js' */
+/** @import InventorySlot from '../Data/InventorySlot.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/destroy_moderator.js
+++ b/Commands/destroy_moderator.js
@@ -3,8 +3,8 @@ import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
 import DestroyAction from "../Data/Actions/DestroyAction.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/dress_moderator.js
+++ b/Commands/dress_moderator.js
@@ -4,8 +4,8 @@ import InventorySlot from '../Data/InventorySlot.js';
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/dress_player.js
+++ b/Commands/dress_player.js
@@ -4,9 +4,9 @@ import InventorySlot from '../Data/InventorySlot.js';
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/drop_moderator.js
+++ b/Commands/drop_moderator.js
@@ -3,10 +3,10 @@ import Fixture from "../Data/Fixture.js";
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/EquipmentSlot.js').default} EquipmentSlot */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/InventoryItem.js').default} InventoryItem */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import EquipmentSlot from '../Data/EquipmentSlot.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import InventoryItem from '../Data/InventoryItem.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/drop_player.js
+++ b/Commands/drop_player.js
@@ -3,11 +3,11 @@ import Fixture from "../Data/Fixture.js";
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/EquipmentSlot.js').default} EquipmentSlot */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/InventoryItem.js').default} InventoryItem */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import EquipmentSlot from '../Data/EquipmentSlot.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import InventoryItem from '../Data/InventoryItem.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/dumplog_moderator.js
+++ b/Commands/dumplog_moderator.js
@@ -1,8 +1,8 @@
 import zlib from 'zlib';
 import fs from 'fs';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/editmode_moderator.js
+++ b/Commands/editmode_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/end_bot.js
+++ b/Commands/end_bot.js
@@ -1,8 +1,8 @@
 import EndAction from "../Data/Actions/EndAction.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/end_moderator.js
+++ b/Commands/end_moderator.js
@@ -1,7 +1,7 @@
 import EndAction from '../Data/Actions/EndAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/endgame_moderator.js
+++ b/Commands/endgame_moderator.js
@@ -1,7 +1,7 @@
 ﻿import { clearQueue } from '../Modules/messageHandler.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 /** @type {CommandConfig} */
 export const config = {
     name: "endgame_moderator",

--- a/Commands/equip_moderator.js
+++ b/Commands/equip_moderator.js
@@ -1,7 +1,7 @@
 import EquipAction from '../Data/Actions/EquipAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/equip_player.js
+++ b/Commands/equip_player.js
@@ -1,8 +1,8 @@
 import EquipAction from '../Data/Actions/EquipAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/exit_bot.js
+++ b/Commands/exit_bot.js
@@ -1,9 +1,9 @@
 ﻿import LockAction from '../Data/Actions/LockAction.js';
 import UnlockAction from '../Data/Actions/UnlockAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/exit_moderator.js
+++ b/Commands/exit_moderator.js
@@ -1,8 +1,8 @@
 ﻿import LockAction from '../Data/Actions/LockAction.js';
 import UnlockAction from '../Data/Actions/UnlockAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/find_moderator.js
+++ b/Commands/find_moderator.js
@@ -8,8 +8,8 @@ import Puzzle from '../Data/Puzzle.js';
 import Recipe from '../Data/Recipe.js';
 import { table } from 'table';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/fixture_bot.js
+++ b/Commands/fixture_bot.js
@@ -2,9 +2,9 @@ import ActivateAction from "../Data/Actions/ActivateAction.js";
 import DeactivateAction from "../Data/Actions/DeactivateAction.js";
 import Room from "../Data/Room.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/fixture_moderator.js
+++ b/Commands/fixture_moderator.js
@@ -2,8 +2,8 @@ import ActivateAction from '../Data/Actions/ActivateAction.js';
 import DeactivateAction from '../Data/Actions/DeactivateAction.js';
 import Room from '../Data/Room.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/flag_bot.js
+++ b/Commands/flag_bot.js
@@ -1,8 +1,8 @@
 import Flag from "../Data/Flag.js";
 import Game from "../Data/Game.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/flag_moderator.js
+++ b/Commands/flag_moderator.js
@@ -1,7 +1,7 @@
 import Flag from '../Data/Flag.js';
 import Game from '../Data/Game.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
+/** @import GameSettings from '../Classes/GameSettings.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/gesture_moderator.js
+++ b/Commands/gesture_moderator.js
@@ -1,8 +1,8 @@
 import GestureAction from '../Data/Actions/GestureAction.js';
 import { createPaginatedEmbed } from '../Modules/discordUtils.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/gesture_player.js
+++ b/Commands/gesture_player.js
@@ -4,9 +4,9 @@ import ItemInstance from '../Data/ItemInstance.js';
 import Puzzle from '../Data/Puzzle.js';
 import { createPaginatedEmbed } from '../Modules/discordUtils.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/give_moderator.js
+++ b/Commands/give_moderator.js
@@ -1,7 +1,7 @@
 import GiveAction from '../Data/Actions/GiveAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/give_player.js
+++ b/Commands/give_player.js
@@ -1,8 +1,8 @@
 import GiveAction from '../Data/Actions/GiveAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/help_eligible.js
+++ b/Commands/help_eligible.js
@@ -1,7 +1,7 @@
 ﻿import { createPaginatedEmbed } from '../Modules/discordUtils.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/help_moderator.js
+++ b/Commands/help_moderator.js
@@ -1,7 +1,7 @@
 ﻿import { createPaginatedEmbed } from '../Modules/discordUtils.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/help_player.js
+++ b/Commands/help_player.js
@@ -1,8 +1,8 @@
 ﻿import { createPaginatedEmbed } from '../Modules/discordUtils.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/hide_moderator.js
+++ b/Commands/hide_moderator.js
@@ -1,8 +1,8 @@
 import HideAction from '../Data/Actions/HideAction.js';
 import UnhideAction from '../Data/Actions/UnhideAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/hide_player.js
+++ b/Commands/hide_player.js
@@ -1,9 +1,9 @@
 import HideAction from '../Data/Actions/HideAction.js';
 import UnhideAction from '../Data/Actions/UnhideAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/inspect_moderator.js
+++ b/Commands/inspect_moderator.js
@@ -1,8 +1,8 @@
 import InspectAction from '../Data/Actions/InspectAction.js';
 import RoomItem from "../Data/RoomItem.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/inspect_player.js
+++ b/Commands/inspect_player.js
@@ -3,9 +3,9 @@ import Fixture from "../Data/Fixture.js";
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/instantiate_bot.js
+++ b/Commands/instantiate_bot.js
@@ -1,9 +1,9 @@
 import InstantiateAction from "../Data/Actions/InstantiateAction.js";
 import RoomItem from "../Data/RoomItem.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/instantiate_moderator.js
+++ b/Commands/instantiate_moderator.js
@@ -2,8 +2,8 @@ import InstantiateAction from '../Data/Actions/InstantiateAction.js';
 import RoomItem from '../Data/RoomItem.js';
 import { instantiateRoomItem, instantiateInventoryItem } from '../Modules/itemManager.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/inventory_moderator.js
+++ b/Commands/inventory_moderator.js
@@ -1,5 +1,5 @@
-﻿/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+﻿/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/inventory_player.js
+++ b/Commands/inventory_player.js
@@ -1,6 +1,6 @@
-﻿/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+﻿/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/kill_bot.js
+++ b/Commands/kill_bot.js
@@ -1,8 +1,8 @@
 import Event from "../Data/Event.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/kill_moderator.js
+++ b/Commands/kill_moderator.js
@@ -1,7 +1,7 @@
 ﻿import DieAction from '../Data/Actions/DieAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/knock_moderator.js
+++ b/Commands/knock_moderator.js
@@ -1,7 +1,7 @@
 import KnockAction from '../Data/Actions/KnockAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/knock_player.js
+++ b/Commands/knock_player.js
@@ -1,8 +1,8 @@
 ﻿import KnockAction from '../Data/Actions/KnockAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/living_moderator.js
+++ b/Commands/living_moderator.js
@@ -1,5 +1,5 @@
-﻿/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+﻿/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/load_moderator.js
+++ b/Commands/load_moderator.js
@@ -1,5 +1,5 @@
-﻿/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+﻿/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/location_moderator.js
+++ b/Commands/location_moderator.js
@@ -1,5 +1,5 @@
-﻿/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+﻿/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/move_bot.js
+++ b/Commands/move_bot.js
@@ -1,9 +1,9 @@
 import Event from "../Data/Event.js";
 import MoveAction from "../Data/Actions/MoveAction.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/move_moderator.js
+++ b/Commands/move_moderator.js
@@ -1,7 +1,7 @@
 import MoveAction from '../Data/Actions/MoveAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/move_player.js
+++ b/Commands/move_player.js
@@ -1,8 +1,8 @@
 import QueueMoveAction from '../Data/Actions/QueueMoveAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/occupants_moderator.js
+++ b/Commands/occupants_moderator.js
@@ -1,7 +1,7 @@
 import { Duration } from 'luxon';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/ongoing_moderator.js
+++ b/Commands/ongoing_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/online_moderator.js
+++ b/Commands/online_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/play_eligible.js
+++ b/Commands/play_eligible.js
@@ -2,8 +2,8 @@
 import { Collection } from 'discord.js';
 import {loadPlayerDefaults} from "../Modules/settingsLoader.ts";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/puzzle_bot.js
+++ b/Commands/puzzle_bot.js
@@ -2,9 +2,9 @@ import AttemptAction from "../Data/Actions/AttemptAction.js";
 import SolveAction from "../Data/Actions/SolveAction.js";
 import UnsolveAction from "../Data/Actions/UnsolveAction.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/puzzle_moderator.js
+++ b/Commands/puzzle_moderator.js
@@ -2,8 +2,8 @@ import AttemptAction from '../Data/Actions/AttemptAction.js';
 import SolveAction from '../Data/Actions/SolveAction.js';
 import UnsolveAction from '../Data/Actions/UnsolveAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/recipes_player.js
+++ b/Commands/recipes_player.js
@@ -2,11 +2,11 @@ import InventoryItem from '../Data/InventoryItem.js';
 import humanize from 'humanize-duration';
 import { createPaginatedEmbed } from '../Modules/discordUtils.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
-/** @typedef {import('../Data/Prefab.js').default} Prefab */
-/** @typedef {import('../Data/ItemInstance.js').default} ItemInstance */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
+/** @import Prefab from '../Data/Prefab.js' */
+/** @import ItemInstance from '../Data/ItemInstance.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/restore_moderator.js
+++ b/Commands/restore_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/reveal_moderator.js
+++ b/Commands/reveal_moderator.js
@@ -1,5 +1,5 @@
-﻿/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+﻿/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/roll_moderator.js
+++ b/Commands/roll_moderator.js
@@ -1,8 +1,8 @@
 ﻿import Die from '../Data/Die.js';
 import Player from '../Data/Player.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/run_player.js
+++ b/Commands/run_player.js
@@ -1,8 +1,8 @@
 import QueueMoveAction from '../Data/Actions/QueueMoveAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/save_moderator.js
+++ b/Commands/save_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/say_moderator.js
+++ b/Commands/say_moderator.js
@@ -3,8 +3,8 @@ import NarrateAction from '../Data/Actions/NarrateAction.js';
 import SayAction from '../Data/Actions/SayAction.js';
 import { ChannelType } from 'discord.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/say_player.js
+++ b/Commands/say_player.js
@@ -2,9 +2,9 @@
 import SayAction from "../Data/Actions/SayAction.js";
 import { ChannelType } from "discord.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/set_bot.js
+++ b/Commands/set_bot.js
@@ -1,8 +1,8 @@
 ﻿import { getChildItems } from '../Modules/itemManager.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/set_moderator.js
+++ b/Commands/set_moderator.js
@@ -1,7 +1,7 @@
 ﻿import { getChildItems } from '../Modules/itemManager.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setdefaultroomicon_bot.js
+++ b/Commands/setdefaultroomicon_bot.js
@@ -1,8 +1,8 @@
 import {writeFile} from 'fs/promises';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setdefaultroomicon_moderator.js
+++ b/Commands/setdefaultroomicon_moderator.js
@@ -1,7 +1,7 @@
 import {writeFile} from 'fs/promises';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setdisplayicon_bot.js
+++ b/Commands/setdisplayicon_bot.js
@@ -1,6 +1,6 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setdisplayicon_moderator.js
+++ b/Commands/setdisplayicon_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setdisplayname_bot.js
+++ b/Commands/setdisplayname_bot.js
@@ -1,6 +1,6 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setdisplayname_moderator.js
+++ b/Commands/setdisplayname_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setpos_bot.js
+++ b/Commands/setpos_bot.js
@@ -1,8 +1,8 @@
 ﻿import Puzzle from "../Data/Puzzle.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setpronouns_bot.js
+++ b/Commands/setpronouns_bot.js
@@ -1,6 +1,6 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setpronouns_moderator.js
+++ b/Commands/setpronouns_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setroomicon_bot.js
+++ b/Commands/setroomicon_bot.js
@@ -1,6 +1,6 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setroomicon_moderator.js
+++ b/Commands/setroomicon_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setupdemo_moderator.js
+++ b/Commands/setupdemo_moderator.js
@@ -1,8 +1,8 @@
 import { registerRoomCategory, createCategory } from '../Modules/serverManager.ts';
 import { ChannelType } from 'discord.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setvoice_bot.js
+++ b/Commands/setvoice_bot.js
@@ -1,6 +1,6 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/setvoice_moderator.js
+++ b/Commands/setvoice_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/sleep_player.js
+++ b/Commands/sleep_player.js
@@ -1,8 +1,8 @@
 import InflictAction from '../Data/Actions/InflictAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/startgame_moderator.js
+++ b/Commands/startgame_moderator.js
@@ -1,8 +1,8 @@
 ﻿import { updateSheetValues } from '../Modules/sheets.js';
 import {loadPlayerDefaults} from "../Modules/settingsLoader.ts";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/stash_moderator.js
+++ b/Commands/stash_moderator.js
@@ -1,7 +1,7 @@
 import StashAction from '../Data/Actions/StashAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/stash_player.js
+++ b/Commands/stash_player.js
@@ -1,8 +1,8 @@
 ﻿import StashAction from '../Data/Actions/StashAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/stats_moderator.js
+++ b/Commands/stats_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/status_bot.js
+++ b/Commands/status_bot.js
@@ -2,10 +2,10 @@ import CureAction from "../Data/Actions/CureAction.js";
 import InflictAction from '../Data/Actions/InflictAction.js';
 import InventoryItem from "../Data/InventoryItem.js";
 
-/** @typedef {import("../Data/Status.js").default} Status */
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import Status from "../Data/Status.js" */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/status_moderator.js
+++ b/Commands/status_moderator.js
@@ -1,10 +1,10 @@
 import CureAction from '../Data/Actions/CureAction.js';
 import InflictAction from '../Data/Actions/InflictAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
-/** @typedef {import("../Data/Status.js").default} Status */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
+/** @import Status from "../Data/Status.js" */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/status_player.js
+++ b/Commands/status_player.js
@@ -1,6 +1,6 @@
-﻿/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+﻿/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/steal_player.js
+++ b/Commands/steal_player.js
@@ -1,8 +1,8 @@
 ﻿import StealAction from '../Data/Actions/StealAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/stop_player.js
+++ b/Commands/stop_player.js
@@ -1,8 +1,8 @@
 ﻿import StopAction from '../Data/Actions/StopAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/tag_bot.js
+++ b/Commands/tag_bot.js
@@ -1,6 +1,6 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/tag_moderator.js
+++ b/Commands/tag_moderator.js
@@ -1,5 +1,5 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/take_moderator.js
+++ b/Commands/take_moderator.js
@@ -3,8 +3,8 @@ import Fixture from "../Data/Fixture.js";
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/take_player.js
+++ b/Commands/take_player.js
@@ -3,9 +3,9 @@ import Fixture from '../Data/Fixture.js';
 import RoomItem from '../Data/RoomItem.js';
 import Puzzle from "../Data/Puzzle.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/testparser_moderator.js
+++ b/Commands/testparser_moderator.js
@@ -7,8 +7,8 @@ import { EOL } from 'os';
 import { Collection } from 'discord.js';
 import {loadPlayerDefaults} from "../Modules/settingsLoader.ts";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/testspeeds_moderator.js
+++ b/Commands/testspeeds_moderator.js
@@ -3,8 +3,8 @@ import Player from '../Data/Player.js';
 import { EOL } from 'os';
 import { Collection } from 'discord.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/text_moderator.js
+++ b/Commands/text_moderator.js
@@ -1,7 +1,7 @@
 import TextAction from '../Data/Actions/TextAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/text_player.js
+++ b/Commands/text_player.js
@@ -1,8 +1,8 @@
 import TextAction from '../Data/Actions/TextAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/time_player.js
+++ b/Commands/time_player.js
@@ -1,6 +1,6 @@
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/trigger_bot.js
+++ b/Commands/trigger_bot.js
@@ -1,8 +1,8 @@
 import TriggerAction from "../Data/Actions/TriggerAction.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/trigger_moderator.js
+++ b/Commands/trigger_moderator.js
@@ -1,7 +1,7 @@
 import TriggerAction from '../Data/Actions/TriggerAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/uncraft_moderator.js
+++ b/Commands/uncraft_moderator.js
@@ -1,7 +1,7 @@
 import UncraftAction from '../Data/Actions/UncraftAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/uncraft_player.js
+++ b/Commands/uncraft_player.js
@@ -1,8 +1,8 @@
 import UncraftAction from '../Data/Actions/UncraftAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/undress_moderator.js
+++ b/Commands/undress_moderator.js
@@ -3,8 +3,8 @@ import Fixture from "../Data/Fixture.js";
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/undress_player.js
+++ b/Commands/undress_player.js
@@ -3,9 +3,9 @@ import Fixture from "../Data/Fixture.js";
 import RoomItem from "../Data/RoomItem.js";
 import Puzzle from "../Data/Puzzle.js";
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/unequip_moderator.js
+++ b/Commands/unequip_moderator.js
@@ -1,8 +1,8 @@
 import UnequipAction from '../Data/Actions/UnequipAction.js';
 import Game from '../Data/Game.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/InventoryItem.js').default} InventoryItem */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import InventoryItem from '../Data/InventoryItem.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/unequip_player.js
+++ b/Commands/unequip_player.js
@@ -1,9 +1,9 @@
 import UnequipAction from '../Data/Actions/UnequipAction.js';
 import Game from '../Data/Game.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/InventoryItem.js').default} InventoryItem */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import InventoryItem from '../Data/InventoryItem.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/unstash_moderator.js
+++ b/Commands/unstash_moderator.js
@@ -1,8 +1,8 @@
 import UnstashAction from '../Data/Actions/UnstashAction.js';
 import InventoryItem from '../Data/InventoryItem.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/unstash_player.js
+++ b/Commands/unstash_player.js
@@ -1,9 +1,9 @@
 import UnstashAction from '../Data/Actions/UnstashAction.js';
 import InventoryItem from '../Data/InventoryItem.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 /** @typedef {import('../Data/InventorySlot.js').default} InventorySlot*/
 
 /** @type {CommandConfig} */

--- a/Commands/unstash_player.js
+++ b/Commands/unstash_player.js
@@ -4,7 +4,6 @@ import InventoryItem from '../Data/InventoryItem.js';
 /** @import GameSettings from '../Classes/GameSettings.js' */
 /** @import Game from '../Data/Game.js' */
 /** @import Player from '../Data/Player.js' */
-/** @typedef {import('../Data/InventorySlot.js').default} InventorySlot*/
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/use_moderator.js
+++ b/Commands/use_moderator.js
@@ -1,7 +1,7 @@
 ﻿import UseAction from '../Data/Actions/UseAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/use_player.js
+++ b/Commands/use_player.js
@@ -3,9 +3,9 @@ import AttemptAction from '../Data/Actions/AttemptAction.js';
 import DeactivateAction from '../Data/Actions/DeactivateAction.js';
 import UseAction from '../Data/Actions/UseAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/wake_player.js
+++ b/Commands/wake_player.js
@@ -1,8 +1,8 @@
 import CureAction from '../Data/Actions/CureAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/whisper_moderator.js
+++ b/Commands/whisper_moderator.js
@@ -3,9 +3,9 @@ import Whisper from '../Data/Whisper.js';
 import SayAction from '../Data/Actions/SayAction.js';
 import WhisperAction from '../Data/Actions/WhisperAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Commands/whisper_player.js
+++ b/Commands/whisper_player.js
@@ -1,9 +1,9 @@
 ﻿import Whisper from '../Data/Whisper.js';
 import WhisperAction from '../Data/Actions/WhisperAction.js';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {CommandConfig} */
 export const config = {

--- a/Data/Action.js
+++ b/Data/Action.js
@@ -1,10 +1,10 @@
 import GameConstruct from "./GameConstruct.js";
 import { randomUUID } from "crypto";
 
-/** @typedef {import("./Game.js").default} Game */
-/** @typedef {import("./Player.js").default} Player */
-/** @typedef {import("./Room.js").default} Room */
-/** @typedef {import("./Whisper.js").default} Whisper */
+/** @import Game from "./Game.js" */
+/** @import Player from "./Player.js" */
+/** @import Room from "./Room.js" */
+/** @import Whisper from "./Whisper.js" */
 
 /**
  * @class Action

--- a/Data/Actions/ActivateAction.js
+++ b/Data/Actions/ActivateAction.js
@@ -1,6 +1,6 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../Fixture.js").default} Fixture */
+/** @import Fixture from "../Fixture.js" */
 
 /**
  * @class ActivateAction

--- a/Data/Actions/AnnounceAction.js
+++ b/Data/Actions/AnnounceAction.js
@@ -1,6 +1,6 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../Dialog.js").default} Dialog */
+/** @import Dialog from "../Dialog.js" */
 
 /**
  * @class AnnounceAction

--- a/Data/Actions/AttemptAction.js
+++ b/Data/Actions/AttemptAction.js
@@ -2,8 +2,8 @@ import Action from "../Action.js";
 import Die from "../Die.js";
 import Player from "../Player.js";
 
-/** @typedef {import("../ItemInstance.js").default} ItemInstance */
-/** @typedef {import("../Puzzle.js").default} Puzzle */
+/** @import ItemInstance from "../ItemInstance.js" */
+/** @import Puzzle from "../Puzzle.js" */
 
 /**
  * @class AttemptAction

--- a/Data/Actions/CraftAction.js
+++ b/Data/Actions/CraftAction.js
@@ -1,7 +1,7 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../Recipe.js").default} Recipe */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import Recipe from "../Recipe.js" */
 
 /**
  * @class CraftAction

--- a/Data/Actions/CureAction.js
+++ b/Data/Actions/CureAction.js
@@ -1,7 +1,7 @@
 import Action from "../Action.js";
 import InflictAction from "./InflictAction.js";
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../Status.js").default} Status */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import Status from "../Status.js" */
 
 /**
  * @class CureAction

--- a/Data/Actions/DeactivateAction.js
+++ b/Data/Actions/DeactivateAction.js
@@ -1,6 +1,6 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../Fixture.js").default} Fixture */
+/** @import Fixture from "../Fixture.js" */
 
 /**
  * @class DeactivateAction

--- a/Data/Actions/DestroyAction.js
+++ b/Data/Actions/DestroyAction.js
@@ -2,8 +2,8 @@ import Action from "../Action.js";
 import { destroyRoomItem, destroyInventoryItem } from "../../Modules/itemManager.js";
 import ItemInstance from "../ItemInstance.js";
 
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../RoomItem.js").default} RoomItem */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import RoomItem from "../RoomItem.js" */
 
 /**
  * @class DestroyAction

--- a/Data/Actions/DressAction.js
+++ b/Data/Actions/DressAction.js
@@ -4,10 +4,10 @@ import InventorySlot from "../InventorySlot.js";
 import Puzzle from "../Puzzle.js";
 import { getSortedItemsString } from "../../Modules/helpers.js";
 
-/** @typedef {import("../EquipmentSlot.js").default} EquipmentSlot */
-/** @typedef {import("../Fixture.js").default} Fixture */
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../RoomItem.js").default} RoomItem */
+/** @import EquipmentSlot from "../EquipmentSlot.js" */
+/** @import Fixture from "../Fixture.js" */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import RoomItem from "../RoomItem.js" */
 
 /**
  * @class DressAction

--- a/Data/Actions/DropAction.js
+++ b/Data/Actions/DropAction.js
@@ -4,10 +4,10 @@ import InventorySlot from "../InventorySlot.js";
 import Puzzle from "../Puzzle.js";
 import { getSortedItemsString } from "../../Modules/helpers.js";
 
-/** @typedef {import("../EquipmentSlot.js").default} EquipmentSlot */
-/** @typedef {import("../Fixture.js").default} Fixture */
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../RoomItem.js").default} RoomItem */
+/** @import EquipmentSlot from "../EquipmentSlot.js" */
+/** @import Fixture from "../Fixture.js" */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import RoomItem from "../RoomItem.js" */
 
 /**
  * @class DropAction

--- a/Data/Actions/EnterAction.js
+++ b/Data/Actions/EnterAction.js
@@ -1,7 +1,7 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../Exit.js").default} Exit */
-/** @typedef {import("../Room.js").default} Room */
+/** @import Exit from "../Exit.js" */
+/** @import Room from "../Room.js" */
 
 /**
  * @class EnterAction

--- a/Data/Actions/EquipAction.js
+++ b/Data/Actions/EquipAction.js
@@ -1,7 +1,7 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../EquipmentSlot.js").default} EquipmentSlot */
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
+/** @import EquipmentSlot from "../EquipmentSlot.js" */
+/** @import InventoryItem from "../InventoryItem.js" */
 
 /**
  * @class EquipAction

--- a/Data/Actions/ExitAction.js
+++ b/Data/Actions/ExitAction.js
@@ -1,7 +1,7 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../Exit.js").default} Exit */
-/** @typedef {import("../Room.js").default} Room */
+/** @import Exit from "../Exit.js" */
+/** @import Room from "../Room.js" */
 
 /**
  * @class ExitAction

--- a/Data/Actions/GestureAction.js
+++ b/Data/Actions/GestureAction.js
@@ -1,11 +1,11 @@
 import Action from "../Action.js";
 import Gesture from "../Gesture.js";
 
-/** @typedef {import("../Exit.js").default} Exit */
-/** @typedef {import("../Fixture.js").default} Fixture */
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../Player.js").default} Player */
-/** @typedef {import("../RoomItem.js").default} RoomItem */
+/** @import Exit from "../Exit.js" */
+/** @import Fixture from "../Fixture.js" */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import Player from "../Player.js" */
+/** @import RoomItem from "../RoomItem.js" */
 
 /**
  * @class GestureAction

--- a/Data/Actions/GiveAction.js
+++ b/Data/Actions/GiveAction.js
@@ -1,8 +1,8 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../EquipmentSlot.js").default} EquipmentSlot */
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../Player.js").default} Player */
+/** @import EquipmentSlot from "../EquipmentSlot.js" */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import Player from "../Player.js" */
 
 /**
  * @class GiveAction

--- a/Data/Actions/HideAction.js
+++ b/Data/Actions/HideAction.js
@@ -1,7 +1,7 @@
 import Action from "../Action.js";
 import InflictAction from "./InflictAction.js";
 
-/** @typedef {import("../HidingSpot.js").default} HidingSpot */
+/** @import HidingSpot from "../HidingSpot.js" */
 
 /**
  * @class HideAction

--- a/Data/Actions/InflictAction.js
+++ b/Data/Actions/InflictAction.js
@@ -1,7 +1,7 @@
 import Action from "../Action.js";
 import CureAction from "./CureAction.js";
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../Status.js").default} Status */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import Status from "../Status.js" */
 
 /**
  * @class InflictAction

--- a/Data/Actions/InspectAction.js
+++ b/Data/Actions/InspectAction.js
@@ -2,9 +2,9 @@ import Action from "../Action.js";
 import Fixture from "../Fixture.js";
 import InventoryItem from "../InventoryItem.js";
 
-/** @typedef {import("../Player.js").default} Player */
-/** @typedef {import("../Room.js").default} Room */
-/** @typedef {import("../RoomItem.js").default} RoomItem */
+/** @import Player from "../Player.js" */
+/** @import Room from "../Room.js" */
+/** @import RoomItem from "../RoomItem.js" */
 
 /**
  * @class InspectAction

--- a/Data/Actions/InstantiateAction.js
+++ b/Data/Actions/InstantiateAction.js
@@ -2,11 +2,11 @@ import Action from "../Action.js";
 import { instantiateRoomItem, instantiateInventoryItem } from "../../Modules/itemManager.js";
 import ItemInstance from "../ItemInstance.js";
 
-/** @typedef {import("../Fixture.js").default} Fixture */
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../Prefab.js").default} Prefab */
-/** @typedef {import("../Puzzle.js").default} Puzzle */
-/** @typedef {import("../RoomItem.js").default} RoomItem */
+/** @import Fixture from "../Fixture.js" */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import Prefab from "../Prefab.js" */
+/** @import Puzzle from "../Puzzle.js" */
+/** @import RoomItem from "../RoomItem.js" */
 
 /**
  * @class InstantiateAction

--- a/Data/Actions/KnockAction.js
+++ b/Data/Actions/KnockAction.js
@@ -1,6 +1,6 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../Exit.js").default} Exit */
+/** @import Exit from "../Exit.js" */
 
 /**
  * @class KnockAction

--- a/Data/Actions/MoveAction.js
+++ b/Data/Actions/MoveAction.js
@@ -3,8 +3,8 @@ import EnterAction from "./EnterAction.js";
 import ExitAction from "./ExitAction.js";
 import SolveAction from "./SolveAction.js";
 
-/** @typedef {import("../Exit.js").default} Exit */
-/** @typedef {import("../Room.js").default} Room */
+/** @import Exit from "../Exit.js" */
+/** @import Room from "../Room.js" */
 
 /**
  * @class MoveAction

--- a/Data/Actions/NarrateAction.js
+++ b/Data/Actions/NarrateAction.js
@@ -5,7 +5,7 @@ import UnhideAction from "./UnhideAction.js";
 import { MessageDisplayType } from "../../Modules/enums.js";
 import { ChannelType } from "discord.js";
 
-/** @typedef {import("../Player.js").default} Player */
+/** @import Player from "../Player.js" */
 
 /**
  * @class NarrateAction

--- a/Data/Actions/QueueMoveAction.js
+++ b/Data/Actions/QueueMoveAction.js
@@ -4,7 +4,7 @@ import Room from "../Room.js";
 import MoveAction from "./MoveAction.js";
 import StartMoveAction from "./StartMoveAction.js";
 
-/** @typedef {import("../Exit.js").default} Exit */
+/** @import Exit from "../Exit.js" */
 
 /**
  * @class QueueMoveAction

--- a/Data/Actions/SayAction.js
+++ b/Data/Actions/SayAction.js
@@ -3,10 +3,10 @@ import SolveAction from "./SolveAction.js";
 import { MessageDisplayType } from "../../Modules/enums.js";
 import { capitalizeFirstLetter } from "../../Modules/helpers.js";
 
-/** @typedef {import("../Dialog.js").default} Dialog */
-/** @typedef {import("../Player.js").default} Player */
-/** @typedef {import("../Puzzle.js").default} Puzzle */
-/** @typedef {import("../Room.js").default} Room */
+/** @import Dialog from "../Dialog.js" */
+/** @import Player from "../Player.js" */
+/** @import Puzzle from "../Puzzle.js" */
+/** @import Room from "../Room.js" */
 
 /**
  * @class SayAction

--- a/Data/Actions/SolveAction.js
+++ b/Data/Actions/SolveAction.js
@@ -1,11 +1,11 @@
 import Action from "../Action.js";
 import Puzzle from "../Puzzle.js";
 
-/** @typedef {import("../Event.js").default} Event */
-/** @typedef {import("../Flag.js").default} Flag */
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../ItemInstance.js").default} ItemInstance */
-/** @typedef {import("../Player.js").default} Player */
+/** @import Event from "../Event.js" */
+/** @import Flag from "../Flag.js" */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import ItemInstance from "../ItemInstance.js" */
+/** @import Player from "../Player.js" */
 
 /**
  * @class SolveAction

--- a/Data/Actions/StartMoveAction.js
+++ b/Data/Actions/StartMoveAction.js
@@ -1,7 +1,7 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../Exit.js").default} Exit */
-/** @typedef {import("../Room.js").default} Room */
+/** @import Exit from "../Exit.js" */
+/** @import Room from "../Room.js" */
 
 /**
  * @class StartMoveAction

--- a/Data/Actions/StashAction.js
+++ b/Data/Actions/StashAction.js
@@ -1,8 +1,8 @@
 import Action from "../Action.js";
 import InventorySlot from "../InventorySlot.js";
 
-/** @typedef {import("../EquipmentSlot.js").default} EquipmentSlot */
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
+/** @import EquipmentSlot from "../EquipmentSlot.js" */
+/** @import InventoryItem from "../InventoryItem.js" */
 
 /**
  * @class StashAction

--- a/Data/Actions/StealAction.js
+++ b/Data/Actions/StealAction.js
@@ -4,8 +4,8 @@ import InventoryItem from "../InventoryItem.js";
 import InventorySlot from "../InventorySlot.js";
 import { MessageDisplayType } from "../../Modules/enums.js";
 
-/** @typedef {import("../EquipmentSlot.js").default} EquipmentSlot */
-/** @typedef {import("../Player.js").default} Player */
+/** @import EquipmentSlot from "../EquipmentSlot.js" */
+/** @import Player from "../Player.js" */
 
 /**
  * @class StealAction

--- a/Data/Actions/StopAction.js
+++ b/Data/Actions/StopAction.js
@@ -1,6 +1,6 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../Exit.js").default} Exit */
+/** @import Exit from "../Exit.js" */
 
 /**
  * @class StopAction

--- a/Data/Actions/TakeAction.js
+++ b/Data/Actions/TakeAction.js
@@ -4,9 +4,9 @@ import InventorySlot from "../InventorySlot.js";
 import Puzzle from "../Puzzle.js";
 import { getSortedItemsString } from "../../Modules/helpers.js";
 
-/** @typedef {import("../EquipmentSlot.js").default} EquipmentSlot */
-/** @typedef {import("../Fixture.js").default} Fixture */
-/** @typedef {import("../RoomItem.js").default} RoomItem */
+/** @import EquipmentSlot from "../EquipmentSlot.js" */
+/** @import Fixture from "../Fixture.js" */
+/** @import RoomItem from "../RoomItem.js" */
 
 /**
  * @class TakeAction

--- a/Data/Actions/TextAction.js
+++ b/Data/Actions/TextAction.js
@@ -1,6 +1,6 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../Player.js").default} Player */
+/** @import Player from "../Player.js" */
 
 /**
  * @class TextAction

--- a/Data/Actions/UncraftAction.js
+++ b/Data/Actions/UncraftAction.js
@@ -1,7 +1,7 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../Recipe.js").default} Recipe */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import Recipe from "../Recipe.js" */
 
 /**
  * @class UncraftAction

--- a/Data/Actions/UndressAction.js
+++ b/Data/Actions/UndressAction.js
@@ -5,9 +5,9 @@ import Puzzle from "../Puzzle.js";
 import DropAction from "./DropAction.js";
 import { getSortedItemsString } from "../../Modules/helpers.js";
 
-/** @typedef {import("../Fixture.js").default} Fixture */
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../RoomItem.js").default} RoomItem */
+/** @import Fixture from "../Fixture.js" */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import RoomItem from "../RoomItem.js" */
 
 /**
  * @class UndressAction

--- a/Data/Actions/UnequipAction.js
+++ b/Data/Actions/UnequipAction.js
@@ -1,7 +1,7 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../EquipmentSlot.js").default} EquipmentSlot */
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
+/** @import EquipmentSlot from "../EquipmentSlot.js" */
+/** @import InventoryItem from "../InventoryItem.js" */
 
 /**
  * @class UnequipAction

--- a/Data/Actions/UnhideAction.js
+++ b/Data/Actions/UnhideAction.js
@@ -1,7 +1,7 @@
 import Action from "../Action.js";
 import CureAction from "./CureAction.js";
 
-/** @typedef {import("../HidingSpot.js").default} HidingSpot */
+/** @import HidingSpot from "../HidingSpot.js" */
 
 /**
  * @class UnhideAction

--- a/Data/Actions/UnsolveAction.js
+++ b/Data/Actions/UnsolveAction.js
@@ -1,9 +1,9 @@
 import Action from "../Action.js";
 import Puzzle from "../Puzzle.js";
 
-/** @typedef {import("../Event.js").default} Event */
-/** @typedef {import("../Flag.js").default} Flag */
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
+/** @import Event from "../Event.js" */
+/** @import Flag from "../Flag.js" */
+/** @import InventoryItem from "../InventoryItem.js" */
 
 /**
  * @class UnsolveAction

--- a/Data/Actions/UnstashAction.js
+++ b/Data/Actions/UnstashAction.js
@@ -1,8 +1,8 @@
 import Action from "../Action.js";
 import InventorySlot from "../InventorySlot.js";
 
-/** @typedef {import("../EquipmentSlot.js").default} EquipmentSlot */
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
+/** @import EquipmentSlot from "../EquipmentSlot.js" */
+/** @import InventoryItem from "../InventoryItem.js" */
 
 /**
  * @class UnstashAction

--- a/Data/Actions/UseAction.js
+++ b/Data/Actions/UseAction.js
@@ -1,7 +1,7 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../InventoryItem.js").default} InventoryItem */
-/** @typedef {import("../Player.js").default} Player */
+/** @import InventoryItem from "../InventoryItem.js" */
+/** @import Player from "../Player.js" */
 
 /**
  * @class UseAction

--- a/Data/Actions/WhisperAction.js
+++ b/Data/Actions/WhisperAction.js
@@ -1,6 +1,6 @@
 import Action from "../Action.js";
 
-/** @typedef {import("../Player.js").default} Player */
+/** @import Player from "../Player.js" */
 
 /**
  * @class WhisperAction

--- a/Data/Dialog.js
+++ b/Data/Dialog.js
@@ -2,11 +2,11 @@ import { Collection } from "discord.js";
 import GameConstruct from "./GameConstruct.js";
 import { capitalizeFirstLetter } from "../Modules/helpers.js";
 
-/** @typedef {import("./Game.js").default} Game */
-/** @typedef {import("./InventoryItem.js").default} InventoryItem */
-/** @typedef {import("./Player.js").default} Player */
-/** @typedef {import("./Room.js").default} Room */
-/** @typedef {import("./Whisper.js").default} Whisper */
+/** @import Game from "./Game.js" */
+/** @import InventoryItem from "./InventoryItem.js" */
+/** @import Player from "./Player.js" */
+/** @import Room from "./Room.js" */
+/** @import Whisper from "./Whisper.js" */
 
 /** @typedef {import("discord.js").Attachment} Attachment */
 /** @typedef {import("discord.js").Embed} Embed */

--- a/Data/Dialog.js
+++ b/Data/Dialog.js
@@ -8,8 +8,8 @@ import { capitalizeFirstLetter } from "../Modules/helpers.js";
 /** @import Room from "./Room.js" */
 /** @import Whisper from "./Whisper.js" */
 
-/** @typedef {import("discord.js").Attachment} Attachment */
-/** @typedef {import("discord.js").Embed} Embed */
+/** @import { Attachment } from "discord.js" */
+/** @import { Embed } from "discord.js" */
 
 /**
  * @class Dialog

--- a/Data/Die.js
+++ b/Data/Die.js
@@ -1,8 +1,8 @@
 ﻿import GameConstruct from './GameConstruct.js';
 import Status from './Status.js';
 
-/** @typedef {import('./Game.js').default} Game */
-/** @typedef {import('./Player.js').default} Player */
+/** @import Game from './Game.js' */
+/** @import Player from './Player.js' */
 
 /**
  * @class Die

--- a/Data/EquipmentSlot.js
+++ b/Data/EquipmentSlot.js
@@ -1,7 +1,7 @@
 ﻿import GameEntity from "./GameEntity.js";
 import InventoryItem from "./InventoryItem.js";
 
-/** @typedef {import("./Game.js").default} Game */
+/** @import Game from "./Game.js" */
 
 /**
  * @class EquipmentSlot

--- a/Data/Event.js
+++ b/Data/Event.js
@@ -5,8 +5,8 @@ import Timer from '../Classes/Timer.js';
 import { DateTime } from 'luxon';
 import { parse } from 'date-fns';
 
-/** @typedef {import('./Game.js').default} Game */
-/** @typedef {import('./Status.js').default} Status */
+/** @import Game from './Game.js' */
+/** @import Status from './Status.js' */
 /** @typedef {import('luxon').Duration} Duration */
 
 /**

--- a/Data/Event.js
+++ b/Data/Event.js
@@ -7,7 +7,7 @@ import { parse } from 'date-fns';
 
 /** @import Game from './Game.js' */
 /** @import Status from './Status.js' */
-/** @typedef {import('luxon').Duration} Duration */
+/** @import { Duration } from 'luxon' */
 
 /**
  * @class Event

--- a/Data/Exit.js
+++ b/Data/Exit.js
@@ -1,7 +1,7 @@
 import GameEntity from './GameEntity.js';
 
-/** @typedef {import('./Game.js').default} Game */
-/** @typedef {import('./Room.js').default} Room */
+/** @import Game from './Game.js' */
+/** @import Room from './Room.js' */
 
 /**
  * @class Exit

--- a/Data/Fixture.js
+++ b/Data/Fixture.js
@@ -7,13 +7,13 @@ import Timer from '../Classes/Timer.js';
 import { getChildItems } from '../Modules/itemManager.js';
 import { Duration } from 'luxon';
 
-/** @typedef {import('./Game.js').default} Game */
-/** @typedef {import('./RoomItem.js').default} RoomItem */
-/** @typedef {import('./Player.js').default} Player */
-/** @typedef {import('./Prefab.js').default} Prefab */
-/** @typedef {import('./Puzzle.js').default} Puzzle */
-/** @typedef {import('./Recipe.js').default} Recipe */
-/** @typedef {import('./Room.js').default} Room */
+/** @import Game from './Game.js' */
+/** @import RoomItem from './RoomItem.js' */
+/** @import Player from './Player.js' */
+/** @import Prefab from './Prefab.js' */
+/** @import Puzzle from './Puzzle.js' */
+/** @import Recipe from './Recipe.js' */
+/** @import Room from './Room.js' */
 
 /**
  * @class Fixture

--- a/Data/Flag.js
+++ b/Data/Flag.js
@@ -2,8 +2,8 @@ import GameEntity from './GameEntity.js';
 import { parseAndExecuteBotCommands } from '../Modules/commandHandler.js';
 import { default as evaluateScript } from '../Modules/scriptParser.js';
 
-/** @typedef {import('./Game.js').default} Game */
-/** @typedef {import('./Player.js').default} Player */
+/** @import Game from './Game.js' */
+/** @import Player from './Player.js' */
 
 /**
  * @class Flag

--- a/Data/Game.js
+++ b/Data/Game.js
@@ -14,20 +14,20 @@ import { sendQueuedMessages } from '../Modules/messageHandler.js';
 import { Collection } from 'discord.js';
 import { DateTime } from 'luxon';
 
-/** @typedef {import('../Classes/GameSettings.js').default} GameSettings */
-/** @typedef {import('../Classes/GuildContext.js').default} GuildContext */
-/** @typedef {import('./Room.js').default} Room */
-/** @typedef {import('./Fixture.js').default} Fixture */
-/** @typedef {import('./Prefab.js').default} Prefab */
-/** @typedef {import('./Recipe.js').default} Recipe */
-/** @typedef {import('./RoomItem.js').default} RoomItem */
-/** @typedef {import('./Puzzle.js').default} Puzzle */
-/** @typedef {import('./Status.js').default} Status */
-/** @typedef {import('./Player.js').default} Player */
-/** @typedef {import('./InventoryItem.js').default} InventoryItem */
-/** @typedef {import('./Gesture.js').default} Gesture */
-/** @typedef {import('./Flag.js').default} Flag */
-/** @typedef {import('./Whisper.js').default} Whisper */
+/** @import GameSettings from '../Classes/GameSettings.js' */
+/** @import GuildContext from '../Classes/GuildContext.js' */
+/** @import Room from './Room.js' */
+/** @import Fixture from './Fixture.js' */
+/** @import Prefab from './Prefab.js' */
+/** @import Recipe from './Recipe.js' */
+/** @import RoomItem from './RoomItem.js' */
+/** @import Puzzle from './Puzzle.js' */
+/** @import Status from './Status.js' */
+/** @import Player from './Player.js' */
+/** @import InventoryItem from './InventoryItem.js' */
+/** @import Gesture from './Gesture.js' */
+/** @import Flag from './Flag.js' */
+/** @import Whisper from './Whisper.js' */
 
 /**
  * @class Game

--- a/Data/GameConstruct.js
+++ b/Data/GameConstruct.js
@@ -1,4 +1,4 @@
-/** @typedef {import("./Game.js").default} Game */
+/** @import Game from "./Game.js" */
 
 /**
  * @class GameConstruct

--- a/Data/GameEntity.js
+++ b/Data/GameEntity.js
@@ -1,6 +1,6 @@
 import GameConstruct from "./GameConstruct.js";
 
-/** @typedef {import("./Game.js").default} Game */
+/** @import Game from "./Game.js" */
 
 /**
  * @class GameEntity

--- a/Data/Gesture.js
+++ b/Data/Gesture.js
@@ -1,12 +1,12 @@
 import GameEntity from "./GameEntity.js";
 
-/** @typedef {import("./Exit.js").default} Exit */
-/** @typedef {import("./Fixture.js").default} Fixture */
-/** @typedef {import("./Game.js").default} Game */
-/** @typedef {import("./InventoryItem.js").default} InventoryItem */
-/** @typedef {import("./RoomItem.js").default} RoomItem */
-/** @typedef {import("./Player.js").default} Player */
-/** @typedef {import("./Status.js").default} Status */
+/** @import Exit from "./Exit.js" */
+/** @import Fixture from "./Fixture.js" */
+/** @import Game from "./Game.js" */
+/** @import InventoryItem from "./InventoryItem.js" */
+/** @import RoomItem from "./RoomItem.js" */
+/** @import Player from "./Player.js" */
+/** @import Status from "./Status.js" */
 
 /**
  * @class Gesture

--- a/Data/HidingSpot.js
+++ b/Data/HidingSpot.js
@@ -2,10 +2,10 @@ import GameEntity from "./GameEntity.js";
 import Whisper from "./Whisper.js";
 import { generatePlayerListString } from "../Modules/helpers.js";
 
-/** @typedef {import("./Action.js").default} Action */
-/** @typedef {import("./Fixture.js").default} Fixture */
-/** @typedef {import("./Game.js").default} Game */
-/** @typedef {import("./Player.js").default} Player */
+/** @import Action from "./Action.js" */
+/** @import Fixture from "./Fixture.js" */
+/** @import Game from "./Game.js" */
+/** @import Player from "./Player.js" */
 
 export default class HidingSpot extends GameEntity {
 	/**

--- a/Data/InventoryItem.js
+++ b/Data/InventoryItem.js
@@ -4,8 +4,8 @@ import { replaceInventoryItem } from '../Modules/itemManager.js';
 import { parseAndExecuteBotCommands } from '../Modules/commandHandler.js';
 import { Collection } from 'discord.js';
 
-/** @typedef {import("./Game.js").default} Game */
-/** @typedef {import("./Player.js").default} Player */
+/** @import Game from "./Game.js" */
+/** @import Player from "./Player.js" */
 
 /**
  * @class InventoryItem

--- a/Data/InventorySlot.js
+++ b/Data/InventorySlot.js
@@ -1,6 +1,6 @@
-/** @typedef {import("./InventoryItem.js").default} InventoryItem */
-/** @typedef {import("./RoomItem.js").default} RoomItem */
-/** @typedef {import("./ItemInstance.js").default} ItemInstance */
+/** @import InventoryItem from "./InventoryItem.js" */
+/** @import RoomItem from "./RoomItem.js" */
+/** @import ItemInstance from "./ItemInstance.js" */
 
 /**
  * @class InventorySlot

--- a/Data/ItemContainer.js
+++ b/Data/ItemContainer.js
@@ -1,8 +1,8 @@
 import GameEntity from "./GameEntity.js";
 import { addItem as addItemToList, removeItem as removeItemFromList } from "../Modules/parser.js";
 
-/** @typedef {import("./Game.js").default} Game */
-/** @typedef {import("./ItemInstance.js").default} ItemInstance */
+/** @import Game from "./Game.js" */
+/** @import ItemInstance from "./ItemInstance.js" */
 
 /**
  * @class ItemContainer

--- a/Data/ItemInstance.js
+++ b/Data/ItemInstance.js
@@ -2,9 +2,9 @@ import InventorySlot from "./InventorySlot.js";
 import ItemContainer from "./ItemContainer.js";
 import { Collection } from "discord.js";
 
-/** @typedef {import("./Game.js").default} Game */
-/** @typedef {import("./Prefab.js").default} Prefab */
-/** @typedef {import("./Player.js").default} Player */
+/** @import Game from "./Game.js" */
+/** @import Prefab from "./Prefab.js" */
+/** @import Player from "./Player.js" */
 
 /**
  * @class ItemInstance

--- a/Data/Narration.js
+++ b/Data/Narration.js
@@ -8,8 +8,7 @@ import { MessageDisplayType } from "../Modules/enums.js";
 /** @import Game from "./Game.js" */
 /** @import Room from "./Room.js" */
 /** @import Whisper from "./Whisper.js" */
-/** @import GameSettings from "../Classes/GameSettings.js" */
-/** @typedef {import("discord.js").GuildMember} GuildMember */
+/** @import { GuildMember } from "discord.js" */
 
 /**
  * @class Narration

--- a/Data/Narration.js
+++ b/Data/Narration.js
@@ -4,11 +4,11 @@ import UnhideAction from "./Actions/UnhideAction.js";
 import { capitalizeFirstLetter } from "../Modules/helpers.js";
 import { MessageDisplayType } from "../Modules/enums.js";
 
-/** @typedef {import("./Action.js").default} Action */
-/** @typedef {import("./Game.js").default} Game */
-/** @typedef {import("./Room.js").default} Room */
-/** @typedef {import("./Whisper.js").default} Whisper */
-/** @typedef {import("../Classes/GameSettings.js").default} GameSettings */
+/** @import Action from "./Action.js" */
+/** @import Game from "./Game.js" */
+/** @import Room from "./Room.js" */
+/** @import Whisper from "./Whisper.js" */
+/** @import GameSettings from "../Classes/GameSettings.js" */
 /** @typedef {import("discord.js").GuildMember} GuildMember */
 
 /**

--- a/Data/Player.js
+++ b/Data/Player.js
@@ -25,8 +25,8 @@ import { Collection } from 'discord.js';
 /** @import Recipe from './Recipe.js' */
 /** @import EquipmentSlot from './EquipmentSlot.js' */
 /** @import InventoryItem from './InventoryItem.js' */
-/** @typedef {import('discord.js').GuildMember} GuildMember */
-/** @typedef {import('discord.js').TextChannel} TextChannel */
+/** @import { GuildMember } from 'discord.js' */
+/** @import { TextChannel } from 'discord.js' */
 
 /**
  * @class Player

--- a/Data/Player.js
+++ b/Data/Player.js
@@ -20,11 +20,11 @@ import { capitalizeFirstLetter } from '../Modules/helpers.js';
 import * as itemManager from '../Modules/itemManager.js';
 import { Collection } from 'discord.js';
 
-/** @typedef {import('./Action.js').default} Action */
-/** @typedef {import('./Exit.js').default} Exit */
-/** @typedef {import('./Recipe.js').default} Recipe */
-/** @typedef {import('./EquipmentSlot.js').default} EquipmentSlot */
-/** @typedef {import('./InventoryItem.js').default} InventoryItem */
+/** @import Action from './Action.js' */
+/** @import Exit from './Exit.js' */
+/** @import Recipe from './Recipe.js' */
+/** @import EquipmentSlot from './EquipmentSlot.js' */
+/** @import InventoryItem from './InventoryItem.js' */
 /** @typedef {import('discord.js').GuildMember} GuildMember */
 /** @typedef {import('discord.js').TextChannel} TextChannel */
 

--- a/Data/Prefab.js
+++ b/Data/Prefab.js
@@ -1,9 +1,9 @@
 ﻿import GameEntity from './GameEntity.js';
 import { Collection } from 'discord.js';
 
-/** @typedef {import('./Game.js').default} Game */
-/** @typedef {import('./InventorySlot.js').default} InventorySlot */
-/** @typedef {import('./Status.js').default} Status */
+/** @import Game from './Game.js' */
+/** @import InventorySlot from './InventorySlot.js' */
+/** @import Status from './Status.js' */
 
 /**
  * @class Prefab

--- a/Data/Puzzle.js
+++ b/Data/Puzzle.js
@@ -5,13 +5,13 @@ import ItemContainer from './ItemContainer.js';
 import { parseAndExecuteBotCommands } from '../Modules/commandHandler.js';
 import { addItem as addItemToList, removeItem as removeItemFromList } from "../Modules/parser.js";
 
-/** @typedef {import('./Fixture.js').default} Fixture */
-/** @typedef {import('./Game.js').default} Game */
-/** @typedef {import('./InventoryItem.js').default} InventoryItem */
-/** @typedef {import('./ItemInstance.js').default} ItemInstance */
-/** @typedef {import('./Player.js').default} Player */
-/** @typedef {import('./Room.js').default} Room */
-/** @typedef {import('./RoomItem.js').default} RoomItem */
+/** @import Fixture from './Fixture.js' */
+/** @import Game from './Game.js' */
+/** @import InventoryItem from './InventoryItem.js' */
+/** @import ItemInstance from './ItemInstance.js' */
+/** @import Player from './Player.js' */
+/** @import Room from './Room.js' */
+/** @import RoomItem from './RoomItem.js' */
 
 /**
  * @class Puzzle

--- a/Data/Recipe.js
+++ b/Data/Recipe.js
@@ -1,7 +1,7 @@
 import GameEntity from './GameEntity.js';
 
-/** @typedef {import('./Game.js').default} Game */
-/** @typedef {import('./Prefab.js').default} Prefab */
+/** @import Game from './Game.js' */
+/** @import Prefab from './Prefab.js' */
 
 /**
  * @class Recipe

--- a/Data/Room.js
+++ b/Data/Room.js
@@ -5,7 +5,7 @@ import { Collection } from 'discord.js';
 /** @import Exit from './Exit.js' */
 /** @import Game from './Game.js' */
 /** @import Player from './Player.js' */
-/** @typedef {import('discord.js').TextChannel} TextChannel */
+/** @import { TextChannel } from 'discord.js' */
 
 /**
  * @class Room

--- a/Data/Room.js
+++ b/Data/Room.js
@@ -2,9 +2,9 @@ import GameEntity from './GameEntity.js';
 import { generatePlayerListString } from '../Modules/helpers.js';
 import { Collection } from 'discord.js';
 
-/** @typedef {import('./Exit.js').default} Exit */
-/** @typedef {import('./Game.js').default} Game */
-/** @typedef {import('./Player.js').default} Player */
+/** @import Exit from './Exit.js' */
+/** @import Game from './Game.js' */
+/** @import Player from './Player.js' */
 /** @typedef {import('discord.js').TextChannel} TextChannel */
 
 /**

--- a/Data/RoomItem.js
+++ b/Data/RoomItem.js
@@ -4,11 +4,11 @@ import DestroyAction from './Actions/DestroyAction.js';
 import InstantiateAction from './Actions/InstantiateAction.js';
 import { Collection } from 'discord.js';
 
-/** @typedef {import('./Fixture.js').default} Fixture */
-/** @typedef {import('./Game.js').default} Game */
-/** @typedef {import('./Player.js').default} Player */
-/** @typedef {import('./Puzzle.js').default} Puzzle */
-/** @typedef {import('./Room.js').default} Room */
+/** @import Fixture from './Fixture.js' */
+/** @import Game from './Game.js' */
+/** @import Player from './Player.js' */
+/** @import Puzzle from './Puzzle.js' */
+/** @import Room from './Room.js' */
 
 /**
  * @class RoomItem

--- a/Data/Status.js
+++ b/Data/Status.js
@@ -1,7 +1,7 @@
 ﻿import GameEntity from './GameEntity.js';
 
-/** @typedef {import('./Game.js').default} Game */
-/** @typedef {import('../Classes/Timer.js').default} Timer */
+/** @import Game from './Game.js' */
+/** @import Timer from '../Classes/Timer.js' */
 
 /**
  * @class Status

--- a/Data/Whisper.js
+++ b/Data/Whisper.js
@@ -6,7 +6,7 @@ import { Collection } from 'discord.js';
 /** @import Action from './Action.js' */
 /** @import Game from './Game.js' */
 /** @import Player from './Player.js' */
-/** @typedef {import('discord.js').TextChannel} TextChannel */
+/** @import { TextChannel } from 'discord.js' */
 
 /**
  * @class Whisper

--- a/Data/Whisper.js
+++ b/Data/Whisper.js
@@ -3,9 +3,9 @@ import Room from './Room.js';
 import { generatePlayerListString } from '../Modules/helpers.js';
 import { Collection } from 'discord.js';
 
-/** @typedef {import('./Action.js').default} Action */
-/** @typedef {import('./Game.js').default} Game */
-/** @typedef {import('./Player.js').default} Player */
+/** @import Action from './Action.js' */
+/** @import Game from './Game.js' */
+/** @import Player from './Player.js' */
 /** @typedef {import('discord.js').TextChannel} TextChannel */
 
 /**

--- a/Modules/commandHandler.js
+++ b/Modules/commandHandler.js
@@ -1,11 +1,11 @@
 ﻿import Puzzle from '../Data/Puzzle.js';
 import { ChannelType } from 'discord.js';
 
-/** @typedef {import('../Data/Event.js').default} Event */
-/** @typedef {import('../Data/Flag.js').default} Flag */
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/InventoryItem.js').default} InventoryItem */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import Event from '../Data/Event.js' */
+/** @import Flag from '../Data/Flag.js' */
+/** @import Game from '../Data/Game.js' */
+/** @import InventoryItem from '../Data/InventoryItem.js' */
+/** @import Player from '../Data/Player.js' */
 
 /**
  * Finds the right command file for the user and executes it.

--- a/Modules/dialogHandler.js
+++ b/Modules/dialogHandler.js
@@ -1,10 +1,10 @@
 ﻿import { ChannelType } from 'discord.js';
 import { addNarration, addSpectatedPlayerMessage } from './messageHandler.js';
 
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Player.js').default} Player */
-/** @typedef {import('../Data/Room.js').default} Room */
-/** @typedef {import('../Data/Whisper.js').default} Whisper */
+/** @import Game from '../Data/Game.js' */
+/** @import Player from '../Data/Player.js' */
+/** @import Room from '../Data/Room.js' */
+/** @import Whisper from '../Data/Whisper.js' */
 
 /**
  * Interprets a dialog message and executes behavior caused by it.

--- a/Modules/finder.js
+++ b/Modules/finder.js
@@ -1,4 +1,4 @@
-/** @typedef {import("../Data/GameEntity.js").default} GameEntity */
+/** @import GameEntity from "../Data/GameEntity.js" */
 
 /** 
  * Wrapper function for the limited scope of  the scriptParser module.

--- a/Modules/helpers.js
+++ b/Modules/helpers.js
@@ -1,9 +1,9 @@
 import { EmbedBuilder } from "discord.js";
 import { Duration } from 'luxon';
 
-/** @typedef {import("../Data/Game.js").default} Game */
-/** @typedef {import("../Data/Player.js").default} Player */
-/** @typedef {import("../Data/RoomItem.js").default} RoomItem */
+/** @import Game from "../Data/Game.js" */
+/** @import Player from "../Data/Player.js" */
+/** @import RoomItem from "../Data/RoomItem.js" */
 /** @typedef {import("luxon").DurationObjectUnits} DurationObjectUnits */
 
 /**

--- a/Modules/helpers.js
+++ b/Modules/helpers.js
@@ -1,10 +1,9 @@
 import { EmbedBuilder } from "discord.js";
 import { Duration } from 'luxon';
 
-/** @import Game from "../Data/Game.js" */
 /** @import Player from "../Data/Player.js" */
 /** @import RoomItem from "../Data/RoomItem.js" */
-/** @typedef {import("luxon").DurationObjectUnits} DurationObjectUnits */
+/** @import { DurationObjectUnits } from "luxon" */
 
 /**
  * Gets a random string out of an array of possibilities.

--- a/Modules/itemManager.js
+++ b/Modules/itemManager.js
@@ -6,10 +6,10 @@ import RoomItem from '../Data/RoomItem.js';
 import ItemInstance from '../Data/ItemInstance.js';
 import { generateProceduralOutput } from '../Modules/parser.js';
 
-/** @typedef {import('../Data/EquipmentSlot.js').default} EquipmentSlot */
-/** @typedef {import('../Data/Prefab.js').default} Prefab */
-/** @typedef {import('../Data/Room.js').default} Room */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import EquipmentSlot from '../Data/EquipmentSlot.js' */
+/** @import Prefab from '../Data/Prefab.js' */
+/** @import Room from '../Data/Room.js' */
+/** @import Player from '../Data/Player.js' */
 
 /**
  * Instantiates a new room item in the specified location and container.

--- a/Modules/messageHandler.js
+++ b/Modules/messageHandler.js
@@ -8,10 +8,10 @@ import { MessageDisplayType } from './enums.js';
 import { capitalizeFirstLetter } from './helpers.js';
 import { MessageFlags, ChannelType, Attachment, Collection, GuildMember, TextChannel, Embed, Webhook } from 'discord.js';
 
-/** @typedef {import('../Data/Game.js').default} Game */
-/** @typedef {import('../Data/Narration.js').default} Narration */
-/** @typedef {import('../Data/Room.js').default} Room */
-/** @typedef {import('../Data/Whisper.js').default} Whisper */
+/** @import Game from '../Data/Game.js' */
+/** @import Narration from '../Data/Narration.js' */
+/** @import Room from '../Data/Room.js' */
+/** @import Whisper from '../Data/Whisper.js' */
 
 /**
  * Processes a message sent in a guild during a game and directs it to the relevant handlers.

--- a/Modules/parser.js
+++ b/Modules/parser.js
@@ -5,9 +5,9 @@ import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 
 export * as default from './parser.js';
 
-/** @typedef {import('../Data/GameEntity.js').default} GameEntity */
-/** @typedef {import('../Data/InventoryItem.js').default} InventoryItem */
-/** @typedef {import('../Data/RoomItem.js').default} RoomItem */
+/** @import GameEntity from '../Data/GameEntity.js' */
+/** @import InventoryItem from '../Data/InventoryItem.js' */
+/** @import RoomItem from '../Data/RoomItem.js' */
 
 class Clause {
     /**

--- a/Modules/scriptParser.js
+++ b/Modules/scriptParser.js
@@ -3,8 +3,8 @@ import * as helpers from './helpers.js';
 
 import { parse as parseScript } from 'acorn';
 
-/** @typedef {import('../Data/GameEntity.js').default} GameEntity */
-/** @typedef {import('../Data/Player.js').default} Player */
+/** @import GameEntity from '../Data/GameEntity.js' */
+/** @import Player from '../Data/Player.js' */
 
 /** @type {import('acorn').Options} */
 const PARSER_OPTIONS = {


### PR DESCRIPTION
This PR refactors all type imports to use `@import` rather than `@typedef`. It also fixes some broken typing in PrettyPrinter and performs minimal pruning of unused type imports.
—💾