### PR TITLE
Improve parseDuration erroneous input handling

### DIFF
--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -932,7 +932,7 @@ export default class GameEntityLoader extends GameEntityManager {
 			return new Error(`Couldn't load recipe on row ${recipe.row}. Recipes with more than 2 ingredients must require a fixture tag.`);
 		if (recipe.products.length > 2 && recipe.fixtureTag === "")
 			return new Error(`Couldn't load recipe on row ${recipe.row}. Recipes with more than 2 products must require a fixture tag.`);
-		if (recipe.duration !== null && !Duration.isDuration(recipe.duration))
+		if (recipe.duration !== null && (Duration.isDuration(recipe.duration) && !recipe.duration.isValid))
 			return new Error(`Couldn't load recipe on row ${recipe.row}. An invalid duration was given.`);
 		if (recipe.fixtureTag === "" && recipe.duration !== null)
 			return new Error(`Couldn't load recipe on row ${recipe.row}. Recipes without a fixture tag cannot have a duration.`);

--- a/Modules/helpers.js
+++ b/Modules/helpers.js
@@ -89,7 +89,7 @@ export function endsWithPunctuation(string) {
 /**
  * Parses a duration string and returns a duration object.
  * @param {string} durationString - An integer and a unit. Acceptable units: y, M, w, d, h, m, s.
- * @returns A duration object, or null.
+ * @returns A duration object.
  */
 export function parseDuration(durationString) {
 	let durationInt = parseInt(durationString.substring(0, durationString.length - 1));
@@ -119,8 +119,11 @@ export function parseDuration(durationString) {
 			case 's':
 				durationInput.seconds = durationInt;
 				break;
+			default:
+				return Duration.invalid("created with duration string using invalid unit", `"${durationUnit}" is an invalid unit`);
 		}
-	}
+	} else return Duration.invalid("created with duration string using invalid duration string", `"${durationString}" is not a valid duration string`);
+	if (!isFinite(durationInt)) return Duration.invalid("created with duration string using invalid period", `"${durationInt}" is not a valid duration period`);
 	return Duration.fromObject(durationInput);
 }
 


### PR DESCRIPTION
Hello! This PR improves upon the `parseDuration()` helper, causing it to return invalid durations given an invalid durationString. This replaces the previous behavior of simply returning a valid zero-length duration. This change passes all previously passing tests for the latest testing commit (6526928a8dda61d51281795e47bd097abc8d1b3e), but requires care moving forward to avoid problems with NaN caused by naïve assumptions of valid output from parseDuration.
—❄️