### PR TITLE
Loosen status modifier regex

### DIFF
--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -1536,7 +1536,7 @@ export default class GameEntityLoader extends GameEntityManager {
 				for (let i = 0; i < cures.length; i++)
 					cures[i] = Status.generateValidId(cures[i]);
 				const modifierStrings = sheet[row][columnStatModifiersString] ? sheet[row][columnStatModifiersString].split(',') : [];
-				const regex = /(@)?(.*)(\+|-|=)(.*)/gi;
+				const regex = /^(@)?([^0-9+=-]+)?(\+|-|=)?(.+)?$/gi;
 				/** @type {StatModifier[]} */
 				let modifiers = [];
 				for (const modifierString of modifierStrings) {


### PR DESCRIPTION
Hello! This PR resolves a too-tight regex for status modifiers in the Status Effects section of the GEL, which prevented certain validation errors relating to status modifiers from appearing.
—❄️