### PR TITLE
Allow GEL player fetching without a name

### DIFF
--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -1738,7 +1738,7 @@ export default class GameEntityLoader extends GameEntityManager {
 					row + 3,
 					this.game
 				);
-				if (this.game.entityFinder.getPlayer(player.name)) {
+				if (this.game.playersCollection.has(Game.generateValidEntityName(player.name))) {
 					errors.push(new Error(`Couldn't load player on row ${player.row}. Another player with this name already exists.`));
 					continue;
 				}

--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -1699,7 +1699,7 @@ export default class GameEntityLoader extends GameEntityManager {
 				let member = null;
 				let notificationChannel = null;
 				let spectateChannel = null;
-				if (sheet[row][columnName] && sheet[row][columnTitle] !== "NPC") {
+				if (sheet[row][columnTitle] !== "NPC") {
 					try {
 						member = sheet[row][columnId] ? this.game.guildContext.guild.members.resolve(sheet[row][columnId].trim()) : null;
 						notificationChannel = await member.createDM();


### PR DESCRIPTION
Hello! Currently, the GEL does not attempt to fetch a member for a player who does not have a name. This causes loader validation to present a misleading error for players without names. Additionally, this tweaks the pre-existing player logic in an attempt to resolve a bug where blank-name players are overwritten by the latest blank-name player.
—❄️