### PR TITLE
Prevent falsy fall-through of plural pronouns

### DIFF
--- a/Data/Player.js
+++ b/Data/Player.js
@@ -480,7 +480,8 @@ export default class Player extends ItemContainer {
                 pronouns.Ipos = pronouns.ipos.charAt(0).toUpperCase() + pronouns.ipos.substring(1);
                 pronouns.ref = pronounSet[4].trim();
                 pronouns.Ref = pronouns.ref.charAt(0).toUpperCase() + pronouns.ref.substring(1);
-                pronouns.plural = pronounSet[5] === "true";
+                const plural = pronounSet[5].trim().toLowerCase();
+                pronouns.plural = plural === "true" ? true : plural === "false" ? false : null;
             }
         }
     }


### PR DESCRIPTION
Hello! This PR prevents the falsy fall-through of whether or not custom pronouns pluralize verbs, thus allowing the GEL to validate if custom pronouns are correctly plural or not.
—❄️