### PR TITLE
Fix GEL validation

### DIFF
--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -1768,8 +1768,7 @@ export default class GameEntityLoader extends GameEntityManager {
 											timeRemaining = Duration.fromObject(timeRemainingParsed);
 										else {
 											errors.push(new Error(`Couldn't load player on row ${player.row}. "${statusDisplay.timeRemaining}" is not a valid representation of the time remaining for the status "${statusDisplay.id}".`));
-                                            invalidStatusFound = true;
-                                            this.game.playersCollection.delete(Game.generateValidEntityName(player.name));
+											invalidStatusFound = true;
 											break;
 										}
 									} else timeRemaining = null;
@@ -1860,7 +1859,7 @@ export default class GameEntityLoader extends GameEntityManager {
 		if (player.alive && !(player.location instanceof Room))
 			return new Error(`Couldn't load player on row ${player.row}. "${player.locationDisplayName}" is not a room.`);
 		for (let statusDisplay of player.statusDisplays) {
-			if (!player.hasStatus(statusDisplay.id))
+			if (!player.hasStatus(statusDisplay.id) && (statusDisplay.timeRemaining ? convertTimeStringToDurationUnits(statusDisplay.timeRemaining) !== undefined : true))
 				return new Error(`Couldn't load player on row ${player.row}. "${statusDisplay.id}" is not a status effect.`);
 		}
 		return;

--- a/Classes/GameEntityLoader.js
+++ b/Classes/GameEntityLoader.js
@@ -1618,7 +1618,7 @@ export default class GameEntityLoader extends GameEntityManager {
 	checkStatusEffect(status) {
 		if (status.id === "" || status.id === null || status.id === undefined)
 			return new Error(`Couldn't load status effect on row ${status.row}. No status effect ID was given.`);
-		if (!validateDuration(status.duration))
+		if (status.duration !== null && !validateDuration(status.duration))
 			return new Error(`Couldn't load status effect on row ${status.row}. An invalid duration was given.`);
 		for (let i = 0; i < status.statModifiers.length; i++) {
 			const statModifier = status.statModifiers[i];
@@ -1768,7 +1768,8 @@ export default class GameEntityLoader extends GameEntityManager {
 											timeRemaining = Duration.fromObject(timeRemainingParsed);
 										else {
 											errors.push(new Error(`Couldn't load player on row ${player.row}. "${statusDisplay.timeRemaining}" is not a valid representation of the time remaining for the status "${statusDisplay.id}".`));
-											invalidStatusFound = true;
+                                            invalidStatusFound = true;
+                                            this.game.playersCollection.delete(Game.generateValidEntityName(player.name));
 											break;
 										}
 									} else timeRemaining = null;


### PR DESCRIPTION
Hello! This PR fixes some cases of unnecessary GEL validation, in one case causing status effects intentionally without a duration to fail to load, and in another case pushing a misleading error message for player duration loading. As a side effect, players that fail status duration validation will not be in the player collection, and likely cannot be inspected via `dumplog`.
—❄️