### PR TITLE
Convert stash_player and stash_moderator to use sliced argument lookups

### DIFF
--- a/Commands/stash_moderator.js
+++ b/Commands/stash_moderator.js
@@ -52,7 +52,7 @@ export async function execute(game, message, command, args) {
     for (let i = 0; i < args.length; i++) {
         for (const item of items) {
             if (item.identifier !== "" && args.slice(i).join(" ") === item.identifier || args.slice(i).join(" ") === item.prefab.id) {
-                if (i === args.length)
+                if (i === 0)
                     return game.communicationHandler.reply(message, `You need to specify two items. Usage:\n${usage(game.settings)}`);
                 containerItem = item;
                 if (item.inventory.size === 0) continue;
@@ -64,7 +64,7 @@ export async function execute(game, message, command, args) {
         if (containerItem !== null && containerItem.inventory.size !== 0) break;
     }
     if (containerItem === null) return game.communicationHandler.reply(message, `Couldn't find container item "${args[args.length - 1]}".`);
-    else if (containerItem.inventory.size === 0) return game.communicationHandler.reply(message, `${containerItem.name} cannot hold items.`);
+    else if (containerItem.inventory.size === 0) return game.communicationHandler.reply(message, `${containerItem.getIdentifier()} cannot hold items.`);
     else if (args[args.length - 1] === "OF") {
         args = args.slice(0, -1);
         input = args.join(" ");
@@ -79,7 +79,7 @@ export async function execute(game, message, command, args) {
             }
             if (containerItemSlot !== null) break;
         }
-        if (containerItemSlot === null) return game.communicationHandler.reply(message, `Couldn't find "${args[args.length - 1]}" of ${containerItem.name}.`);
+        if (containerItemSlot === null) return game.communicationHandler.reply(message, `Couldn't find "${args[args.length - 1]}" of ${containerItem.getIdentifier()}.`);
     }
     args = args.slice(0, -1);
     input = args.join(" ");

--- a/Commands/stash_moderator.js
+++ b/Commands/stash_moderator.js
@@ -42,64 +42,55 @@ export async function execute(game, message, command, args) {
     if (player === undefined) return game.communicationHandler.reply(message, `Player "${args[0]}" not found.`);
     args.splice(0, 1);
 
-    const input = args.join(' ');
-    let parsedInput = input.toUpperCase().replace(/\'/g, "");
-    let newArgs = parsedInput.split(' ');
+    let input = args.join(' ').toUpperCase().replace(/\'/g, "");
+    args = input.split(' ');
 
     // Look for the container item.
     const items = game.inventoryItems.filter(item => item.player.name === player.name && item.prefab !== null && item.quantity !== 0);
     let containerItem = null;
     let containerItemSlot = null;
-    for (let i = 0; i < items.length; i++) {
-        if (items[i].identifier !== "" && parsedInput.endsWith(items[i].identifier) && parsedInput !== items[i].identifier ||
-            parsedInput.endsWith(items[i].prefab.id) && parsedInput !== items[i].prefab.id ||
-            parsedInput.endsWith(items[i].name) && parsedInput !== items[i].name) {
-            containerItem = items[i];
-            if (items[i].inventory.size === 0) continue;
-
-            if (items[i].identifier !== "" && parsedInput.endsWith(items[i].identifier))
-                parsedInput = parsedInput.substring(0, parsedInput.lastIndexOf(items[i].identifier)).trimEnd();
-            else if (parsedInput.endsWith(items[i].prefab.id))
-                parsedInput = parsedInput.substring(0, parsedInput.lastIndexOf(items[i].prefab.id)).trimEnd();
-            else if (parsedInput.endsWith(items[i].name))
-                parsedInput = parsedInput.substring(0, parsedInput.lastIndexOf(items[i].name)).trimEnd();
-
-            // Check if a slot was specified.
-            if (parsedInput.endsWith(" OF")) {
-                parsedInput = parsedInput.substring(0, parsedInput.lastIndexOf(" OF")).trimEnd();
-                newArgs = parsedInput.split(' ');
-                for (const [id, slot] of containerItem.inventory) {
-                    if (parsedInput.endsWith(id)) {
-                        containerItemSlot = slot;
-                        parsedInput = parsedInput.substring(0, parsedInput.lastIndexOf(id)).trimEnd();
-                        break;
-                    }
-                }
-                if (containerItemSlot === null) return game.communicationHandler.reply(message, `Couldn't find "${newArgs[newArgs.length - 1]}" of ${containerItem.identifier}.`);
+    for (let i = 0; i < args.length; i++) {
+        for (const item of items) {
+            if (item.identifier !== "" && args.slice(i).join(" ") === item.identifier || args.slice(i).join(" ") === item.prefab.id) {
+                if (i === args.length)
+                    return game.communicationHandler.reply(message, `You need to specify two items. Usage:\n${usage(game.settings)}`);
+                containerItem = item;
+                if (item.inventory.size === 0) continue;
+                args = args.slice(0, i);
+                input = args.join(" ");
+                break;
             }
-            newArgs = parsedInput.split(' ');
-            newArgs.splice(newArgs.length - 1, 1);
-            parsedInput = newArgs.join(' ');
-            break;
         }
-        else if (items[i].identifier !== "" && parsedInput === items[i].identifier ||
-            parsedInput === items[i].prefab.id ||
-            parsedInput === items[i].name) {
-            game.communicationHandler.reply(message, `You need to specify two items. Usage:`);
-            game.communicationHandler.sendToCommandChannel(usage(game.settings));
-            return;
-        }
+        if (containerItem !== null && containerItem.inventory.size !== 0) break;
     }
-    if (containerItem === null) return game.communicationHandler.reply(message, `Couldn't find container item "${newArgs[newArgs.length - 1]}".`);
-    else if (containerItem.inventory.size === 0) return game.communicationHandler.reply(message, `${containerItem.prefab.id} cannot hold items.`);
+    if (containerItem === null) return game.communicationHandler.reply(message, `Couldn't find container item "${args[args.length - 1]}".`);
+    else if (containerItem.inventory.size === 0) return game.communicationHandler.reply(message, `${containerItem.name} cannot hold items.`);
+    else if (args[args.length - 1] === "OF") {
+        args = args.slice(0, -1);
+        input = args.join(" ");
+        for (let i = 0; i < args.length; i++) {
+            for (const [id, slot] of containerItem.inventory) {
+                if (args.slice(i).join(" ") === id) {
+                    containerItemSlot = slot;
+                    args = args.slice(0, i);
+                    input = args.join(" ");
+                    break;
+                }
+            }
+            if (containerItemSlot !== null) break;
+        }
+        if (containerItemSlot === null) return game.communicationHandler.reply(message, `Couldn't find "${args[args.length - 1]}" of ${containerItem.name}.`);
+    }
+    args = args.slice(0, -1);
+    input = args.join(" ");
 
     // Now find the item in the player's inventory.
-    const hand = game.entityFinder.getPlayerHandHoldingItem(player, parsedInput, containerItem.row);
+    const hand = game.entityFinder.getPlayerHandHoldingItem(player, input, containerItem.row);
     // Make sure item and containerItem aren't the same item.
-    if (!hand && game.entityFinder.getPlayerHandHoldingItem(player, parsedInput))
+    if (!hand && game.entityFinder.getPlayerHandHoldingItem(player, input))
         return game.communicationHandler.reply(message, `Can't stash ${containerItem.getIdentifier()} ${containerItem.prefab.preposition} itself.`);
     const item = hand ? hand.equippedItem : undefined;
-    if (item === undefined) return game.communicationHandler.reply(message, `Couldn't find item "${parsedInput}" in either of ${player.name}'s hands.`);
+    if (item === undefined) return game.communicationHandler.reply(message, `Couldn't find item "${input}" in either of ${player.name}'s hands.`);
     // Ensure an inventory item can't be stashed inside an inventory item that it contains.
     let container = containerItem.container;
     while (container !== null) {

--- a/Commands/stash_player.js
+++ b/Commands/stash_player.js
@@ -40,7 +40,7 @@ export function usage(settings) {
  * @param {Player} player - The player who issued the command.
  */
 export async function execute(game, message, command, args, player) {
-    if (args.length === 0)
+    if (args.length < 2)
         return game.communicationHandler.reply(message, `You need to specify two items. Usage:\n${usage(game.settings)}`);
 
     const status = player.getBehaviorAttributeStatusEffects("disable stash");
@@ -56,7 +56,7 @@ export async function execute(game, message, command, args, player) {
     for (let i = 0; i < args.length; i++) {
         for (const item of items) {
             if (args.slice(i).join(" ") === item.name) {
-                if (i === args.length)
+                if (i === 0)
                     return game.communicationHandler.reply(message, `You need to specify two items. Usage:\n${usage(game.settings)}`);
                 containerItem = item;
                 if (item.inventory.size === 0) continue;

--- a/Commands/stash_player.js
+++ b/Commands/stash_player.js
@@ -22,8 +22,8 @@ export const config = {
 };
 
 /**
- * @param {GameSettings} settings 
- * @returns {string} 
+ * @param {GameSettings} settings
+ * @returns {string}
  */
 export function usage(settings) {
     return `${settings.commandPrefix}stash LAPTOP in BEIGE SATCHEL\n`
@@ -33,11 +33,11 @@ export function usage(settings) {
 }
 
 /**
- * @param {Game} game - The game in which the command is being executed. 
- * @param {UserMessage} message - The message in which the command was issued. 
- * @param {string} command - The command alias that was used. 
- * @param {string[]} args - A list of arguments passed to the command as individual words. 
- * @param {Player} player - The player who issued the command. 
+ * @param {Game} game - The game in which the command is being executed.
+ * @param {UserMessage} message - The message in which the command was issued.
+ * @param {string} command - The command alias that was used.
+ * @param {string[]} args - A list of arguments passed to the command as individual words.
+ * @param {Player} player - The player who issued the command.
  */
 export async function execute(game, message, command, args, player) {
     if (args.length === 0)
@@ -46,50 +46,55 @@ export async function execute(game, message, command, args, player) {
     const status = player.getBehaviorAttributeStatusEffects("disable stash");
     if (status.length > 0) return game.communicationHandler.reply(message, `You cannot do that because you are **${status[0].id}**.`);
 
-    const input = args.join(' ');
-    let parsedInput = input.toUpperCase().replace(/\'/g, "");
-    let newArgs = parsedInput.split(' ');
+    let input = args.join(' ').toUpperCase().replace(/\'/g, "");
+    args = input.split(' ');
 
     // Look for the container item.
     const items = game.inventoryItems.filter(item => item.player.name === player.name && item.prefab !== null && item.quantity !== 0);
     let containerItem = null;
     let containerItemSlot = null;
-    for (let i = 0; i < items.length; i++) {
-        if (items[i].prefab !== null && parsedInput.endsWith(items[i].name) && parsedInput !== items[i].name) {
-            containerItem = items[i];
-            if (items[i].inventory.size === 0) continue;
-            parsedInput = parsedInput.substring(0, parsedInput.lastIndexOf(items[i].name)).trimEnd();
-            // Check if a slot was specified.
-            if (parsedInput.endsWith(" OF")) {
-                parsedInput = parsedInput.substring(0, parsedInput.lastIndexOf(" OF")).trimEnd();
-                newArgs = parsedInput.split(' ');
-                for (const [id, slot] of containerItem.inventory) {
-                    if (parsedInput.endsWith(id)) {
-                        containerItemSlot = slot;
-                        parsedInput = parsedInput.substring(0, parsedInput.lastIndexOf(id)).trimEnd();
-                        break;
-                    }
-                }
-                if (containerItemSlot === null) return game.communicationHandler.reply(message, `Couldn't find "${newArgs[newArgs.length - 1]}" of ${containerItem.name}.`);
+    for (let i = 0; i < args.length; i++) {
+        for (const item of items) {
+            if (args.slice(i).join(" ") === item.name) {
+                if (i === args.length)
+                    return game.communicationHandler.reply(message, `You need to specify two items. Usage:\n${usage(game.settings)}`);
+                containerItem = item;
+                if (item.inventory.size === 0) continue;
+                args = args.slice(0, i);
+                input = args.join(" ");
+                break;
             }
-            newArgs = parsedInput.split(' ');
-            newArgs.splice(newArgs.length - 1, 1);
-            parsedInput = newArgs.join(' ');
-            break;
         }
-        else if (parsedInput === items[i].name)
-            return game.communicationHandler.reply(message, `You need to specify two items. Usage:\n${usage(game.settings)}`);
+        if (containerItem !== null && containerItem.inventory.size !== 0) break;
     }
-    if (containerItem === null) return game.communicationHandler.reply(message, `Couldn't find container item "${newArgs[newArgs.length - 1]}".`);
+    if (containerItem === null) return game.communicationHandler.reply(message, `Couldn't find container item "${args[args.length - 1]}".`);
     else if (containerItem.inventory.size === 0) return game.communicationHandler.reply(message, `${containerItem.name} cannot hold items. Contact a moderator if you believe this is a mistake.`);
+    else if (args[args.length - 1] === "OF") {
+        args = args.slice(0, -1);
+        input = args.join(" ");
+        for (let i = 0; i < args.length; i++) {
+            for (const [id, slot] of containerItem.inventory) {
+                if (args.slice(i).join(" ") === id) {
+                    containerItemSlot = slot;
+                    args = args.slice(0, i);
+                    input = args.join(" ");
+                    break;
+                }
+            }
+            if (containerItemSlot !== null) break;
+        }
+        if (containerItemSlot === null) return game.communicationHandler.reply(message, `Couldn't find "${args[args.length - 1]}" of ${containerItem.name}.`);
+    }
+    args = args.slice(0, -1);
+    input = args.join(" ");
 
     // Now find the item in the player's inventory.
-    const hand = game.entityFinder.getPlayerHandHoldingItem(player, parsedInput, containerItem.row, "player");
+    const hand = game.entityFinder.getPlayerHandHoldingItem(player, input, containerItem.row, "player");
     // Make sure item and containerItem aren't the same item.
-    if (!hand && game.entityFinder.getPlayerHandHoldingItem(player, parsedInput))
+    if (!hand && game.entityFinder.getPlayerHandHoldingItem(player, input))
         return game.communicationHandler.reply(message, `You can't stash ${containerItem.name} ${containerItem.prefab.preposition} itself.`);
     const item = hand ? hand.equippedItem : undefined;
-    if (item === undefined) return game.communicationHandler.reply(message, `Couldn't find item "${parsedInput}" in either of your hands. If this item is elsewhere in your inventory, please unequip or unstash it before trying to stash it.`);
+    if (item === undefined) return game.communicationHandler.reply(message, `Couldn't find item "${input}" in either of your hands. If this item is elsewhere in your inventory, please unequip or unstash it before trying to stash it.`);
     // Ensure an inventory item can't be stashed inside an inventory item that it contains.
     let container = containerItem.container;
     while (container !== null) {

--- a/Test/Commands/stash_moderator.test.js
+++ b/Test/Commands/stash_moderator.test.js
@@ -2,14 +2,109 @@ import ModeratorCommand from "../../Classes/ModeratorCommand.js";
 import { usage, execute, config } from '../../Commands/stash_moderator.js'
 import { clearQueue, sendQueuedMessages } from "../../Modules/messageHandler.js";
 import { createMockMessage } from "../__mocks__/libs/discord.js";
+import StashAction from '../../Data/Actions/StashAction.js';
 
 describe('stash_moderator command', () => {
+    beforeAll(async () => {
+        if (!game.inProgress) await game.entityLoader.loadAll();
+    });
+
     afterEach(async () => {
         clearQueue(game);
         vi.resetAllMocks();
     });
 
     const stash_moderator = new ModeratorCommand(config, usage, execute);
-        
-    test('', async () => {});
+
+    describe('valid invocations', () => {
+        afterEach(async () => {
+            await game.entityLoader.loadInventoryItems(false);
+        });
+
+        test('valid item into specified slot of equipped item', async () => {
+            const player = game.entityFinder.getPlayer("Kyra");
+            const hand = game.entityFinder.getPlayerHandHoldingItem(player, "mug of coffee");
+            const coffee = hand.items[0];
+            const jacket = game.entityFinder.getPlayerEquipmentSlotWithEquippedItem(player, "kyras lab coat");
+            /** @type {StashAction} */
+            let context;
+            const original = StashAction.prototype.performStash;
+            const spy = vi.spyOn(StashAction.prototype, "performStash");
+            spy.mockImplementation(function (...args) {
+                context = this;
+                return original.apply(this, args);
+            });
+            // @ts-ignore
+            await stash_moderator.execute(game, createMockMessage(), "stash", ["kyra's", "mug", "of", "coffee", "in", "right", "pocket", "of", "kyras", "lab", "coat"]);
+            expect(spy).toBeInvokedWith(coffee, hand, jacket.items[0], jacket.items[0].inventory.get("RIGHT POCKET"));
+            expect(context).not.toBeUndefined();
+            expect(context.player.name).toBe(player.name);
+        });
+
+        test('valid item into unspecified slot of equipped item', async () => {
+            const player = game.entityFinder.getPlayer("Kyra");
+            const hand = game.entityFinder.getPlayerHandHoldingItem(player, "mug of coffee");
+            const coffee = hand.items[0];
+            const jacket = game.entityFinder.getPlayerEquipmentSlotWithEquippedItem(player, "kyras lab coat");
+            /** @type {StashAction} */
+            let context;
+            const original = StashAction.prototype.performStash;
+            const spy = vi.spyOn(StashAction.prototype, "performStash");
+            spy.mockImplementation(function (...args) {
+                context = this;
+                return original.apply(this, args);
+            });
+            // @ts-ignore
+            await stash_moderator.execute(game, createMockMessage(), "stash", ["kyra's", "mug", "of", "coffee", "in", "kyras", "lab", "coat"]);
+            expect(spy).toBeInvokedWith(coffee, hand, jacket.items[0], jacket.items[0].inventory.get("RIGHT POCKET"));
+            expect(context).not.toBeUndefined();
+            expect(context.player.name).toBe(player.name);
+        });
+    });
+
+    describe('invalid invocations', () => {
+        test('valid item into invalid slot of equipped item', async () => {
+            const spy = vi.spyOn(StashAction.prototype, "performStash");
+            const message = createMockMessage();
+            const author = message.author;
+            // @ts-ignore
+            await stash_moderator.execute(game, message, "stash", ["kyra's", "mug", "of", "coffee", "in", "invalid", "pocket", "of", "kyras", "lab", "coat"]);
+            await sendQueuedMessages(game);
+            expect(spy).not.toHaveBeenCalled();
+            expect(author.send).toBeInvokedWith("Couldn't find \"POCKET\" of KYRAS LAB COAT 1.");
+        });
+
+        test('valid item into slot of invalid item', async () => {
+            const spy = vi.spyOn(StashAction.prototype, "performStash");
+            const message = createMockMessage();
+            const author = message.author;
+            // @ts-ignore
+            await stash_moderator.execute(game, message, "stash", ["kyra's", "mug", "of", "coffee", "in", "right", "pocket", "of", "kyras", "invalid", "coat"]);
+            await sendQueuedMessages(game);
+            expect(spy).not.toHaveBeenCalled();
+            expect(author.send).toBeInvokedWith("Couldn't find container item \"COAT\".");
+        });
+
+        test('valid item into unspecified slot of item without capacity', async () => {
+            const spy = vi.spyOn(StashAction.prototype, "performStash");
+            const message = createMockMessage();
+            const author = message.author;
+            // @ts-ignore
+            await stash_moderator.execute(game, message, "stash", ["kyra's", "mug", "of", "coffee", "in", "kyras", "glasses"]);
+            await sendQueuedMessages(game);
+            expect(spy).not.toHaveBeenCalled();
+            expect(author.send).toBeInvokedWith("KYRAS GLASSES cannot hold items.");
+        });
+
+        test('valid item without container', async () => {
+            const spy = vi.spyOn(StashAction.prototype, "performStash");
+            const message = createMockMessage();
+            const author = message.author;
+            // @ts-ignore
+            await stash_moderator.execute(game, message, "stash", ["kyra's", "mug", "of", "coffee"]);
+            await sendQueuedMessages(game);
+            expect(spy).not.toHaveBeenCalled();
+            expect(author.send).toBeInvokedWith(`You need to specify two items. Usage:\n${stash_moderator.usage(game.settings)}`);
+        });
+    });
 });

--- a/Test/Commands/stash_player.test.js
+++ b/Test/Commands/stash_player.test.js
@@ -2,14 +2,113 @@ import PlayerCommand from "../../Classes/PlayerCommand.js";
 import { usage, execute, config } from '../../Commands/stash_player.js'
 import { clearQueue, sendQueuedMessages } from "../../Modules/messageHandler.js";
 import { createMockMessage } from "../__mocks__/libs/discord.js";
+import StashAction from '../../Data/Actions/StashAction.js';
 
 describe('stash_player command', () => {
+    beforeAll(async () => {
+        if (!game.inProgress) await game.entityLoader.loadAll();
+    });
+
     afterEach(async () => {
         clearQueue(game);
         vi.resetAllMocks();
     });
 
     const stash_player = new PlayerCommand(config, usage, execute);
-        
-    test('', async () => {});
+
+    describe('valid invocations', () => {
+        afterEach(async () => {
+            await game.entityLoader.loadInventoryItems(false);
+        });
+
+        test('valid item into specified slot of equipped item', async () => {
+            const player = game.entityFinder.getPlayer("Kyra");
+            const hand = game.entityFinder.getPlayerHandHoldingItem(player, "mug of coffee");
+            const coffee = hand.items[0];
+            const jacket = game.entityFinder.getPlayerEquipmentSlotWithEquippedItem(player, "kyras lab coat");
+            /** @type {StashAction} */
+            let context;
+            const original = StashAction.prototype.performStash;
+            const spy = vi.spyOn(StashAction.prototype, "performStash");
+            spy.mockImplementation(function (...args) {
+                context = this;
+                return original.apply(this, args);
+            });
+            // @ts-ignore
+            await stash_player.execute(game, createMockMessage(), "stash", ["coffee", "in", "right", "pocket", "of", "lab", "coat"], player);
+            expect(spy).toBeInvokedWith(coffee, hand, jacket.items[0], jacket.items[0].inventory.get("RIGHT POCKET"));
+            expect(context).not.toBeUndefined();
+            expect(context.player.name).toBe(player.name);
+        });
+
+        test('valid item into unspecified slot of equipped item', async () => {
+            const player = game.entityFinder.getPlayer("Kyra");
+            const hand = game.entityFinder.getPlayerHandHoldingItem(player, "mug of coffee");
+            const coffee = hand.items[0];
+            const jacket = game.entityFinder.getPlayerEquipmentSlotWithEquippedItem(player, "kyras lab coat");
+            /** @type {StashAction} */
+            let context;
+            const original = StashAction.prototype.performStash;
+            const spy = vi.spyOn(StashAction.prototype, "performStash");
+            spy.mockImplementation(function (...args) {
+                context = this;
+                return original.apply(this, args);
+            });
+            // @ts-ignore
+            await stash_player.execute(game, createMockMessage(), "stash", ["coffee", "in", "lab", "coat"], player);
+            expect(spy).toBeInvokedWith(coffee, hand, jacket.items[0], jacket.items[0].inventory.get("RIGHT POCKET"));
+            expect(context).not.toBeUndefined();
+            expect(context.player.name).toBe(player.name);
+        });
+    });
+
+    describe('invalid invocations', () => {
+        test('valid item into invalid slot of equipped item', async () => {
+            const player = game.entityFinder.getPlayer("Kyra");
+            const spy = vi.spyOn(StashAction.prototype, "performStash");
+            const message = createMockMessage();
+            const author = message.author;
+            // @ts-ignore
+            await stash_player.execute(game, message, "stash", ["coffee", "in", "invalid", "pocket", "of", "lab", "coat"], player);
+            await sendQueuedMessages(game);
+            expect(spy).not.toHaveBeenCalled();
+            expect(author.send).toBeInvokedWith("Couldn't find \"POCKET\" of LAB COAT.");
+        });
+
+        test('valid item into slot of invalid item', async () => {
+            const player = game.entityFinder.getPlayer("Kyra");
+            const spy = vi.spyOn(StashAction.prototype, "performStash");
+            const message = createMockMessage();
+            const author = message.author;
+            // @ts-ignore
+            await stash_player.execute(game, message, "stash", ["coffee", "in", "right", "pocket", "of", "invalid", "coat"], player);
+            await sendQueuedMessages(game);
+            expect(spy).not.toHaveBeenCalled();
+            expect(author.send).toBeInvokedWith("Couldn't find container item \"COAT\".");
+        });
+
+        test('valid item into unspecified slot of item without capacity', async () => {
+            const player = game.entityFinder.getPlayer("Kyra");
+            const spy = vi.spyOn(StashAction.prototype, "performStash");
+            const message = createMockMessage();
+            const author = message.author;
+            // @ts-ignore
+            await stash_player.execute(game, message, "stash", ["coffee", "in", "glasses"], player);
+            await sendQueuedMessages(game);
+            expect(spy).not.toHaveBeenCalled();
+            expect(author.send).toBeInvokedWith("GLASSES cannot hold items. Contact a moderator if you believe this is a mistake.");
+        });
+
+        test('valid item without container', async () => {
+            const player = game.entityFinder.getPlayer("Kyra");
+            const spy = vi.spyOn(StashAction.prototype, "performStash");
+            const message = createMockMessage();
+            const author = message.author;
+            // @ts-ignore
+            await stash_player.execute(game, message, "stash", ["coffee"], player);
+            await sendQueuedMessages(game);
+            expect(spy).not.toHaveBeenCalled();
+            expect(author.send).toBeInvokedWith(`You need to specify two items. Usage:\n${stash_player.usage(game.settings)}`);
+        });
+    });
 });


### PR DESCRIPTION
This PR converts the stash_player and stash_moderator commands to use sliced argument lookups, instead of the old endsWith style lookups, which caused pocket names that were substrings of other pocket names to behave oddly.
—🦇