### PR TITLE
Allow mod commands to be used anywhere

### DIFF
--- a/Classes/GameCommunicationHandler.js
+++ b/Classes/GameCommunicationHandler.js
@@ -12,7 +12,7 @@ import { Attachment, Collection, Embed, TextChannel } from "discord.js";
 /** @import GameEntity from "../Data/GameEntity.js" */
 /** @import Narration from "../Data/Narration.js" */
 /** @import Player from "../Data/Player.js" */
-/** @import { Snowflake } from "discord.js" */
+/** @import { GuildMember, Snowflake, User } from "discord.js" */
 
 /**
  * @class GameCommunicationHandler
@@ -134,8 +134,13 @@ export default class GameCommunicationHandler {
 	 * @param {UserMessage} message - The message to reply to.
 	 * @param {string} messageText - The text of the message to send in response.
 	 */
-	reply(message, messageText) {
-		messageHandler.sendReply(this.#game, message, messageText);
+    reply(message, messageText) {
+        let member = game.guildContext.guild.members.resolve(message.author.id);
+        if (member && member.roles.cache.has(game.guildContext.moderatorRole.id)) {
+            messageHandler.sendGameMechanicMessage(this.#game, this.#game.guildContext.commandChannel, `<@${message.author.id}>: ${messageText}`);
+        } else {
+            messageHandler.sendReply(this.#game, message, messageText);
+        }
 	}
 
 	/**

--- a/Classes/GameCommunicationHandler.js
+++ b/Classes/GameCommunicationHandler.js
@@ -35,7 +35,7 @@ export default class GameCommunicationHandler {
 	 * @readonly
 	 */
 	#actionCacheSizeLimit = 20;
-	/** 
+	/**
 	 * A collection of mirrored dialog messages to allow edits to dialog messages to be reflected in spectate channels.
 	 * The key is the ID of the original message that's being mirrored.
 	 * @type {Collection<string, DialogSpectateMirror[]>}
@@ -66,7 +66,7 @@ export default class GameCommunicationHandler {
 
 	/**
 	 * Adds an action to the cache. If the cache is at maximum capacity, removes the oldest one.
-	 * @param {Action} action - The action to cache. 
+	 * @param {Action} action - The action to cache.
 	 */
 	#addActionToCache(action) {
 		if (this.#actionCache.size >= this.#actionCacheSizeLimit)
@@ -76,7 +76,7 @@ export default class GameCommunicationHandler {
 
 	/**
 	 * Caches a channel for a given action.
-	 * @param {Action} action - The action to cache a channel for. 
+	 * @param {Action} action - The action to cache a channel for.
 	 * @param {string} channelId - The channel to cache.
 	 */
 	#cacheChannelFor(action, channelId) {
@@ -101,7 +101,7 @@ export default class GameCommunicationHandler {
 
 	/**
 	 * Adds the message to the dialog cache.
-	 * @param {UserMessage} message - The message that initiated the dialog. 
+	 * @param {UserMessage} message - The message that initiated the dialog.
 	 */
 	cacheDialog(message) {
 		if (this.#dialogSpectateMirrorCache.size >= this.#dialogSpectateMirrorCacheSizeLimit)
@@ -135,8 +135,8 @@ export default class GameCommunicationHandler {
 	 * @param {string} messageText - The text of the message to send in response.
 	 */
     reply(message, messageText) {
-        let member = game.guildContext.guild.members.resolve(message.author.id);
-        if (member && member.roles.cache.has(game.guildContext.moderatorRole.id)) {
+        let member = this.#game.guildContext.guild.members.resolve(message.author.id);
+        if (member && member.roles.cache.has(this.#game.guildContext.moderatorRole.id)) {
             messageHandler.sendGameMechanicMessage(this.#game, this.#game.guildContext.commandChannel, `<@${message.author.id}>: ${messageText}`);
         } else {
             messageHandler.sendReply(this.#game, message, messageText);
@@ -229,7 +229,7 @@ export default class GameCommunicationHandler {
 	 * @param {string} webhookAvatarURL - The avatar URL to use for the mirrored webhook message.
 	 * @param {string} messageText - The text of the message to send.
 	 * @param {MessageDisplayType} messageDisplayType - The type of message to send.
-	 * @param {Embed[]} [embeds] - An array of embeds to send in the message. Optional. 
+	 * @param {Embed[]} [embeds] - An array of embeds to send in the message. Optional.
 	 * @param {string[]} [files] - An array of URLs to send as attachments. Optional.
 	 * @param {UserMessage} [message] - The message being mirrored. Optional.
 	 */

--- a/Classes/GameCommunicationHandler.js
+++ b/Classes/GameCommunicationHandler.js
@@ -4,7 +4,7 @@ import Room from "../Data/Room.js";
 import * as messageHandler from "../Modules/messageHandler.js";
 import { parseDescription } from "../Modules/parser.js";
 import { capitalizeFirstLetter } from "../Modules/helpers.js";
-import { Attachment, Collection, Embed, TextChannel } from "discord.js";
+import { Attachment, ChannelType, Collection, Embed, TextChannel } from "discord.js";
 
 /** @import Description from '../Data/Description.js' */
 /** @import Dialog from "../Data/Dialog.js" */
@@ -136,8 +136,8 @@ export default class GameCommunicationHandler {
 	 */
     reply(message, messageText) {
         let member = this.#game.guildContext.guild.members.resolve(message.author.id);
-        if (member && member.roles.cache.has(this.#game.guildContext.moderatorRole.id)) {
-            messageHandler.sendGameMechanicMessage(this.#game, this.#game.guildContext.commandChannel, `<@${message.author.id}>: ${messageText}`);
+        if (member && member.roles.cache.has(this.#game.guildContext.moderatorRole.id) && message.channel.id !== this.#game.guildContext.commandChannel.id && message.channel.type !== ChannelType.DM) {
+            messageHandler.sendGameMechanicMessage(this.#game, this.#game.guildContext.commandChannel, `<@${message.author.id}>, ${messageText}`);
         } else {
             messageHandler.sendReply(this.#game, message, messageText);
         }

--- a/Modules/commandHandler.js
+++ b/Modules/commandHandler.js
@@ -63,26 +63,29 @@ export async function executeCommand(commandStr, game, message, player, callee) 
         return true;
     }
     else if (isModerator) {
-        if (moderatorCommand.config.requiresGame && !game.inProgress) {
-            if (message.channel.id === game.guildContext.commandChannel.id) {
-                message.reply("There is no game currently running.");
-                return false;
-            } else {
-                message.author.send("There is no game currently running.");
-                message.delete();
-                return false;
+        if (message.channel.type === ChannelType.GuildText && (message.channel.id === game.guildContext.commandChannel.id || game.guildContext.roomCategories.includes(message.channel.parentId) || commandStr.startsWith('delete'))) {
+            if (moderatorCommand.config.requiresGame && !game.inProgress) {
+                if (message.channel.id === game.guildContext.commandChannel.id) {
+                    message.reply("There is no game currently running.");
+                    return false;
+                } else {
+                    message.author.send("There is no game currently running.");
+                    message.delete();
+                    return false;
+                }
             }
+            moderatorCommand.execute(game, message, commandAlias, args);
+            if (message.channel.id !== game.guildContext.commandChannel.id)
+                message.delete();
+            entry = {
+                timestamp: new Date(),
+                author: message.author.username,
+                content: message.content
+            };
+            game.botContext.commandLog.push(entry);
+            return true;
         }
-        moderatorCommand.execute(game, message, commandAlias, args);
-        if (message.channel.id !== game.guildContext.commandChannel.id)
-            message.delete();
-        entry = {
-            timestamp: new Date(),
-            author: message.author.username,
-            content: message.content
-        };
-        game.botContext.commandLog.push(entry);
-        return true;
+        return false;
     }
     else if (isPlayer) {
         if (playerCommand.config.requiresGame && !game.inProgress) {

--- a/Modules/commandHandler.js
+++ b/Modules/commandHandler.js
@@ -1,10 +1,7 @@
 ﻿import Puzzle from '../Data/Puzzle.js';
 import { ChannelType } from 'discord.js';
 
-/** @import Event from '../Data/Event.js' */
-/** @import Flag from '../Data/Flag.js' */
 /** @import Game from '../Data/Game.js' */
-/** @import InventoryItem from '../Data/InventoryItem.js' */
 /** @import Player from '../Data/Player.js' */
 
 /**
@@ -20,14 +17,12 @@ export async function executeCommand(commandStr, game, message, player, callee) 
     let isBot = false, isModerator = false, isPlayer = false, isEligible = false;
     // First, determine who is using the command.
     if (!message) isBot = true;
-    else if ((message.channel.id === game.guildContext.commandChannel.id || commandStr.startsWith('delete'))
-        && message.member.roles.cache.has(game.guildContext.moderatorRole.id))
-        isModerator = true;
     else {
         // Don't attempt to find the member who sent this message if it was sent by a webhook.
         if (message.webhookId !== null) return false;
         let member = game.guildContext.guild.members.resolve(message.author.id);
-        if (member && member.roles.cache.has(game.guildContext.playerRole.id)) isPlayer = true;
+        if (member && member.roles.cache.has(game.guildContext.moderatorRole.id)) isModerator = true;
+        else if (member && member.roles.cache.has(game.guildContext.playerRole.id)) isPlayer = true;
         else if (member && game.settings.debug && member.roles.cache.has(game.guildContext.testerRole.id)) isEligible = true;
         else if (member && !game.settings.debug && member.roles.cache.has(game.guildContext.eligibleRole.id)) isEligible = true;
     }
@@ -69,10 +64,18 @@ export async function executeCommand(commandStr, game, message, player, callee) 
     }
     else if (isModerator) {
         if (moderatorCommand.config.requiresGame && !game.inProgress) {
-            message.reply("There is no game currently running.");
-            return false;
+            if (message.channel.id === game.guildContext.commandChannel.id) {
+                message.reply("There is no game currently running.");
+                return false;
+            } else {
+                message.author.send("There is no game currently running.");
+                message.delete();
+                return false;
+            }
         }
         moderatorCommand.execute(game, message, commandAlias, args);
+        if (message.channel.id !== game.guildContext.commandChannel.id)
+            message.delete();
         entry = {
             timestamp: new Date(),
             author: message.author.username,
@@ -154,7 +157,6 @@ export async function executeCommand(commandStr, game, message, player, callee) 
 }
 
 /**
- * 
  * @param {string[]} commandSet - A list of bot commands to pass into the command handler's execute function.
  * @param {Game} game - The game in which the command is being executed.
  * @param {Callee} callee - The in-game entity that caused the command to be executed.
@@ -187,7 +189,7 @@ export async function parseAndExecuteBotCommands(commandSet, game, callee, playe
 }
 
 /**
- * @param {number} seconds 
+ * @param {number} seconds
  */
 function sleep(seconds) {
     return new Promise(resolve => setTimeout(resolve, seconds * 1000));


### PR DESCRIPTION
This PR resolves #327 by removing the command channel gate in the command handler, and tweaking the Game Communication Handler's `reply` function to operate differently for moderators. Initial manual testing, as well as autotesting, suggests no breakage to any commands caused by these changes.
—🦇