### PR TITLE
Lock messageQueue when fully dequeueing

### DIFF
--- a/Classes/PriorityQueue.js
+++ b/Classes/PriorityQueue.js
@@ -17,6 +17,11 @@ export default class PriorityQueue {
      * @type {Collection<PriorityQueuePriority, StackQueue<MessageQueueEntry>>}
      */
     queues;
+    /** 
+     * Whether or not the PriorityQueue is "Firing", that is, whether or not it is being fully dequeued by the Message Handler.
+     * @type {boolean}
+     */
+    firing;
 
     constructor() {
         this.priorityOrder = ['mod', 'tell', 'mechanic', 'log', 'spectator'];
@@ -24,6 +29,7 @@ export default class PriorityQueue {
         for (let i = 0; i < this.priorityOrder.length; i++) {
             this.queues.set(this.priorityOrder[i], new StackQueue());
         }
+        this.firing = false;
     }
 
     /**

--- a/Modules/messageHandler.js
+++ b/Modules/messageHandler.js
@@ -415,6 +415,8 @@ export async function sendWebhookMessage(webhook, content, username, avatarURL, 
  * @param {Game} game - The game whose message queue should have its messages sent.
  */
 export async function sendQueuedMessages(game) {
+    if (game.messageQueue.firing) return;
+    game.messageQueue.firing = true;
     while (game.messageQueue.size() > 0) {
         const message = game.messageQueue.dequeue();
         try {
@@ -423,6 +425,7 @@ export async function sendQueuedMessages(game) {
             console.error("Message Handler encountered exception sending message:", error);
         }
     }
+    game.messageQueue.firing = false;
 }
 
 /**

--- a/Modules/messageHandler.js
+++ b/Modules/messageHandler.js
@@ -417,15 +417,18 @@ export async function sendWebhookMessage(webhook, content, username, avatarURL, 
 export async function sendQueuedMessages(game) {
     if (game.messageQueue.firing) return;
     game.messageQueue.firing = true;
-    while (game.messageQueue.size() > 0) {
-        const message = game.messageQueue.dequeue();
-        try {
-            await message.fire();
-        } catch (error) {
-            console.error("Message Handler encountered exception sending message:", error);
+    try {
+        while (game.messageQueue.size() > 0) {
+            const message = game.messageQueue.dequeue();
+            try {
+                await message.fire();
+            } catch (error) {
+                console.error("Message Handler encountered exception sending message:", error);
+            }
         }
+    } finally {
+        game.messageQueue.firing = false;
     }
-    game.messageQueue.firing = false;
 }
 
 /**


### PR DESCRIPTION
This PR tweaks the messageHandler so that sendQueuedMesssages does not indiscriminately fire every second, and instead immediately terminates if sendQueuedMessages is already running. This is accomplished by adding a simple boolean flag to the messageQueue, which signals whether or not it is currently in a "firing" state.
—🦇