### PR TITLE
Implement deletion mirroring for spectator messages

### DIFF
--- a/Modules/messageHandler.js
+++ b/Modules/messageHandler.js
@@ -100,9 +100,9 @@ export function sendNarrationToRoom(room, narration, messageText, messageDisplay
 
 /**
  * Narrates a message to a whisper.
- * @param {Whisper} whisper - The whisper to send the message to. 
+ * @param {Whisper} whisper - The whisper to send the message to.
  * @param {Narration} narration - The narration being sent.
- * @param {string} messageText - The message to send. 
+ * @param {string} messageText - The message to send.
  * @param {string} messageTextWithSpectatePrefix - The message to send with a prefix for spectate channels indicating which whisper the narration occurred in.
  * @param {MessageDisplayType} messageDisplayType - The display type of the message to send.
  * @param {boolean} [addSpectate] - Whether or not to mirror the message in spectate channels. Defaults to true.
@@ -174,10 +174,10 @@ export function sendNotification(player, messageText, messageDisplayType, addSpe
 /**
  * Sends the room description to a player as an array of Discord Components.
  * @param {Player} player - The player to send the message to.
- * @param {Room} location - The room whose description is being sent. 
- * @param {string} descriptionText - The description of the room to send. 
+ * @param {Room} location - The room whose description is being sent.
+ * @param {string} descriptionText - The description of the room to send.
  * @param {string} occupantsString - The list of occupants in the room.
- * @param {string} defaultDropFixtureText - The description of the default drop fixture in this room. 
+ * @param {string} defaultDropFixtureText - The description of the default drop fixture in this room.
  * @param {boolean} [addSpectate] - Whether or not to mirror the message in spectate channels. Defaults to true.
  */
 export function sendRoomDescription(player, location, descriptionText, occupantsString, defaultDropFixtureText, addSpectate = true) {
@@ -328,7 +328,7 @@ export function sendNarrationSpectateMessage(player, messageText, messageDisplay
  * @param {string} messageText - The text of the message to send.
  * @param {string} webhookUsername - The username to use for the mirrored webhook message.
  * @param {string} webhookAvatarURL - The avatar URL to use for the mirrored webhook message.
- * @param {Embed[]} [embeds] - An array of embeds to send in the message. Optional. 
+ * @param {Embed[]} [embeds] - An array of embeds to send in the message. Optional.
  * @param {string[]} [files] - An array of URLs to send as attachments. Optional.
  * @param {UserMessage} [message] - The message being mirrored. Optional.
  * @param {MessageDisplayType} [messageDisplayType] - The type of message to send. Defaults to PLAIN_TEXT.
@@ -383,8 +383,22 @@ export function editSpectatorMessage(game, messageOld, messageNew) {
 }
 
 /**
+ * Edits spectate messages when the dialog they mirror is edited.
+ * @param {Game} game - The game this dialog belongs to.
+ * @param {UserMessage|import('discord.js').PartialMessage} message - The message being deleted.
+ */
+export function deleteSpectatorMessage(game, message) {
+    const spectateMirrors = game.communicationHandler.getDialogSpectateMirrors(message);
+    if (!spectateMirrors) return;
+    spectateMirrors.forEach(async (mirror) => {
+        const webhook = await message.client.fetchWebhook(mirror.webhookId);
+        webhook.deleteMessage(mirror.messageId);
+    });
+}
+
+/**
  * Gets the client's webhook for the given channel, or creates one if it doesn't exist already.
- * @param {TextChannel} channel - The channel to get or create a webhook for. 
+ * @param {TextChannel} channel - The channel to get or create a webhook for.
  */
 export async function getOrCreateWebhook(channel) {
     const webhooks = await channel.fetchWebhooks();
@@ -397,10 +411,10 @@ export async function getOrCreateWebhook(channel) {
 /**
  * Sends a webhook message in the specified channel.
  * @param {Webhook} webhook - The channel to send the webhook message to.
- * @param {string} content - The content of the message to send. 
- * @param {string} username - The username of the webhook message. 
- * @param {string} avatarURL - The URL of the icon to use for the webhook message. 
- * @param {Embed[]} [embeds] - An array of embeds to send in the message. Optional. 
+ * @param {string} content - The content of the message to send.
+ * @param {string} username - The username of the webhook message.
+ * @param {string} avatarURL - The URL of the icon to use for the webhook message.
+ * @param {Embed[]} [embeds] - An array of embeds to send in the message. Optional.
  * @param {string[]} [files] - An array of URLs to send as attachments. Optional.
  * @param {Game} [game] - The game the message is for. Optional.
  * @param {MessageDisplayType} [messageDisplayType] - The type of message to send. Defaults to PLAIN_TEXT.
@@ -426,7 +440,7 @@ export async function sendQueuedMessages(game) {
 }
 
 /**
- * @param {Game} game - The game whose message queue should be emptied. 
+ * @param {Game} game - The game whose message queue should be emptied.
  */
 export function clearQueue(game) {
     game.messageQueue.clear();

--- a/bot.js
+++ b/bot.js
@@ -11,7 +11,7 @@ import EligibleCommand from './Classes/EligibleCommand.js';
 
 import {createServerConfigFileIfNotExists, loadServerConfig, validateServerConfig} from './Modules/serverManager.ts';
 import { default as autoUpdate } from './Modules/updateHandler.js';
-import { editSpectatorMessage, processIncomingMessage } from './Modules/messageHandler.js';
+import { editSpectatorMessage, deleteSpectatorMessage, processIncomingMessage } from './Modules/messageHandler.js';
 import { executeCommand } from './Modules/commandHandler.js';
 
 import { Client, Collection, ChannelType, GatewayIntentBits, Partials, TextChannel, Role } from 'discord.js';
@@ -282,6 +282,16 @@ client.on('messageUpdate', async (messageOld, messageNew) => {
             || messageOld.channel.parentId === game.guildContext.whisperCategoryId
             || messageOld.channel.id === game.guildContext.announcementChannel.id)) {
         editSpectatorMessage(game, messageOld, messageNew);
+    }
+});
+
+client.on('messageDelete', async (message) => {
+    if (!initialized) return;
+    if (message.channel.type !== ChannelType.DM && game.inProgress
+        && (game.guildContext.roomCategories.includes(message.channel.parentId)
+            || message.channel.parentId === game.guildContext.whisperCategoryId
+            || message.channel.id === game.guildContext.announcementChannel.id)) {
+        deleteSpectatorMessage(game, message);
     }
 });
 


### PR DESCRIPTION
This PR implements deletion mirroring for spectator messages. As a limitation, this uses nigh-identical logical to edit mirroring, and thus will (presumably) only mirror deletion for messages that would also have edits mirrored.
—🦇