### PR TITLE
Allow stack trace limit to be defined with environment variables

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -22,7 +22,7 @@ import GameSettings from "./Classes/GameSettings.js";
 import { loadCredentials } from "./Modules/credentialsLoader.ts";
 
 if (process.env.STACK_TRACE_LIMIT && Number.isInteger(parseInt(process.env.STACK_TRACE_LIMIT))) {
-    Error.stackTraceLimit = Math.min(Math.max(10, parseInt(process.env.STACK_TRACE_LIMIT)), 200);
+    Error.stackTraceLimit = Math.min(Math.max(10, Math.round(parseInt(process.env.STACK_TRACE_LIMIT))), 200);
 }
 
 const client = new Client({

--- a/bot.js
+++ b/bot.js
@@ -21,6 +21,10 @@ import { loadGameSettings, loadPlayerDefaults } from "./Modules/settingsLoader.t
 import GameSettings from "./Classes/GameSettings.js";
 import { loadCredentials } from "./Modules/credentialsLoader.ts";
 
+if (process.env.STACK_TRACE_LIMIT && Number.isInteger(parseInt(process.env.STACK_TRACE_LIMIT))) {
+    Error.stackTraceLimit = Math.min(Math.max(10, parseInt(process.env.STACK_TRACE_LIMIT)), 200);
+}
+
 const client = new Client({
     partials: [
         Partials.User,


### PR DESCRIPTION
Hello! The default Node.js stack trace limit is 10, but this can be increased at runtime. This PR implements simple environment variable-based modifications to the stack trace limit, with a minimum of 10 and a maximum of 200. I am unsure of how helpful this would be, but I sincerely doubt it would be a hindrance to never interact with.
—❄️