### PR TITLE
Finish implementation of CollatedRoomItem.decreaseUses()

### DIFF
--- a/Data/CollatedRoomItem.js
+++ b/Data/CollatedRoomItem.js
@@ -121,11 +121,6 @@ export default class CollatedRoomItem {
         const step = Math.min(Math.floor(ingredientUseCount / item.quantity), item.uses);
 				// If step === 0, then we're on an item whose quantity prevents clean division of ingredientUseCount.
 				if (step === 0) {
-				  if (item.quantity === 1) {
-						console.error("Erroneous step?");
-						console.error({ uses: item.uses, quantity: item.quantity, iuc: ingredientUseCount, iucq: ingredientUseCount / item.quantity, iucqf: Math.floor(ingredientUseCount / item.quantity), cu: this.uses, cq: this.quantity, step: step });
-						throw new Error();
-					}
 				  // First, check if there's an item that *doesn't* have this issue; if there is, continue.
 					if (this.items.find((findItem) => Math.min(Math.floor(ingredientUseCount / findItem.quantity), findItem.uses) > 0) !== undefined) continue;
 					// Next, check if we could simply consume one item off this stack to handle the remainder.

--- a/Data/CollatedRoomItem.js
+++ b/Data/CollatedRoomItem.js
@@ -95,30 +95,92 @@ export default class CollatedRoomItem {
 	}
 
 	/**
+	 * Recalculates uses and quantity stats.
+	 */
+	#recalculate() {
+		this.quantity = this.items.reduce((quantity, item) => quantity + (isNaN(item.quantity) ? NaN : item.quantity), 0);
+		this.uses = this.items.reduce((uses, item) => uses + (isNaN(item.uses) ? NaN : item.quantity * item.uses), 0);
+	}
+
+	/**
 	 * Decreases the collated room items' uses.
 	 * @param {number} ingredientUseCount - The number of times to use the item.
 	 */
 	decreaseUses(ingredientUseCount) {
-		// Sort collated items by lowest number of uses to highest.
-		this.items.sort((a, b) => a.uses - b.uses);
-		let stepSize = 1;
-		for (let i = 0; i < ingredientUseCount; i += stepSize) {
+		// Sort collated items by lowest number of uses to highest, sorting within use by lowest quantity to highest.
+		this.items.sort((a, b) => a.uses !== b.uses ? a.uses - b.uses : a.quantity - b.quantity);
+		while (ingredientUseCount > 0) {
+		  // Early exit if total uses or total quantity is equal to zero.
+			if (this.uses === 0 || this.quantity === 0) return;
 			for (const item of this.items) {
-				if (item.uses <= 0) continue;
-				const remainingDecrementValue = ingredientUseCount - i;
-				const stepSizeRemainder = remainingDecrementValue % (item.uses - stepSize);
-				if (item.quantity > 1 && i + item.quantity < ingredientUseCount && stepSizeRemainder === 0)
-					stepSize = item.quantity;
-				if (item.quantity > 1 && stepSizeRemainder !== 0) {
-					// TODO: figure out how to handle this.
+			  // Return if ingredientUseCount is 0.
+			  if (ingredientUseCount === 0) return;
+        // Continue to next item if uses is 0 or NaN or if quantity is 0.
+        if (item.uses === 0 || item.quantity === 0 || isNaN(item.uses)) continue;
+        // Define step as the lowest of either item.uses or ⌊ingredientUseCount/item.quantity⌋.
+        const step = Math.min(Math.floor(ingredientUseCount / item.quantity), item.uses);
+				// If step === 0, then we're on an item whose quantity prevents clean division of ingredientUseCount.
+				if (step === 0) {
+				  if (item.quantity === 1) {
+						console.error("Erroneous step?");
+						console.error({ uses: item.uses, quantity: item.quantity, iuc: ingredientUseCount, iucq: ingredientUseCount / item.quantity, iucqf: Math.floor(ingredientUseCount / item.quantity), cu: this.uses, cq: this.quantity, step: step });
+						throw new Error();
+					}
+				  // First, check if there's an item that *doesn't* have this issue; if there is, continue.
+					if (this.items.find((findItem) => Math.min(Math.floor(ingredientUseCount / findItem.quantity), findItem.uses) > 0) !== undefined) continue;
+					// Next, check if we could simply consume one item off this stack to handle the remainder.
+					if (ingredientUseCount === item.uses) {
+					  // Decrement quantity by 1 and decrement ingredientUseCount by item.uses.
+						item.quantity -= 1;
+						ingredientUseCount -= item.uses;
+						// Store nextStage.
+						const nextStage = item.prefab.nextStage;
+  					if (nextStage)
+  					  // If we have a nextStage, we should instantiate it accordingly.
+  						this.instantiate(nextStage, 1);
+  					// Re-sort.
+  					this.items.sort((a, b) => a.uses !== b.uses ? a.uses - b.uses : a.quantity - b.quantity);
+  					// Re-calculate stats.
+  					this.#recalculate();
+  					// Break, to refresh this for loop.
+  					break;
+					}
+					// Otherwise, split one item off of this stack.
+					item.quantity -= 1;
+					const split = this.instantiate(item.prefab, 1);
+					// Manually set the newly split item's uses to be equal to the current stack's uses.
+					split.uses = item.uses;
+					this.items.push(split);
+					// Sort the collated items again so that the newly-split item is positioned properly.
+					this.items.sort((a, b) => a.uses !== b.uses ? a.uses - b.uses : a.quantity - b.quantity);
+					// Re-calculate stats.
+					this.#recalculate();
+					// Break so that we immediately re-enter the loop.
+					break;
 				}
-				item.uses -= stepSize;
+				// We go here if step is greater than zero.
+				// First, decrement the item's uses, the collated uses, and the ingredientUseCount by the current step.
+				item.uses -= step;
+				ingredientUseCount -= step * item.quantity;
+				// Check if the item uses is equal to zero.
 				if (item.uses === 0) {
+				  // Grab references now so we don't lose them when the item is destroyed.
 					const nextStage = item.prefab.nextStage;
+					const quantity = item.quantity;
+					// Destroy the item.
 					this.destroy(item);
-					if (nextStage) this.instantiate(nextStage, stepSize);
+					if (nextStage)
+					  // If we have a nextStage, we should instantiate it accordingly.
+						this.instantiate(nextStage, quantity);
+					// Re-sort.
+					this.items.sort((a, b) => a.uses !== b.uses ? a.uses - b.uses : a.quantity - b.quantity);
+					// Re-calculate stats.
+					this.#recalculate();
+					// Break, on the off-chance this is the last loop we need.
+					break;
 				}
-				break;
+				// Re-calculate stats.
+				this.#recalculate();
 			}
 		}
 	}
@@ -157,6 +219,6 @@ export default class CollatedRoomItem {
 	 */
 	instantiate(prefab, quantity) {
 		const instantiateAction = new InstantiateAction(prefab.getGame(), undefined, undefined, this.location, true);
-		instantiateAction.performInstantiateRoomItem(prefab, this.container, this.slot, quantity, new Map());
+		return instantiateAction.performInstantiateRoomItem(prefab, this.container, this.slot, quantity, new Map());
 	}
 }

--- a/Test/Data/CollatedRoomItem.test.js
+++ b/Test/Data/CollatedRoomItem.test.js
@@ -219,6 +219,48 @@ describe('CollatedRoomItem test', () => {
 			expect(detergent3.uses).toBeNaN();
 		});
 
+		test('decrease uses of detergent in video room SINK 1 by 3', () => {
+			const sink = game.entityFinder.getFixture("SINK 1", "video-room");
+			const items = CollatedRoomItem.collate(getSortedItems(sink.getContainedItems()));
+			const detergent = items[0];
+			detergent.decreaseUses(3);
+			const newItems = sink.getContainedItems();
+			expect(newItems).toHaveLength(4);
+			const detergent1 = newItems[1];
+			const detergent2 = newItems[2];
+			const detergent3 = newItems[3];
+			expect(detergent1.prefab.id).toBe("DETERGENT");
+			expect(detergent2.prefab.id).toBe("DETERGENT");
+			expect(detergent3.prefab.id).toBe("EMPTY DETERGENT BOTTLE");
+			expect(detergent1.quantity).toBe(2);
+			expect(detergent2.quantity).toBe(1);
+			expect(detergent3.quantity).toBe(1);
+			expect(detergent1.uses).toBe(4);
+			expect(detergent2.uses).toBe(2);
+			expect(detergent3.uses).toBeNaN();
+		});
+
+		test('decrease uses of detergent in video room SINK 1 by 4', () => {
+			const sink = game.entityFinder.getFixture("SINK 1", "video-room");
+			const items = CollatedRoomItem.collate(getSortedItems(sink.getContainedItems()));
+			const detergent = items[0];
+			detergent.decreaseUses(4);
+			const newItems = sink.getContainedItems();
+			expect(newItems).toHaveLength(4);
+			const detergent1 = newItems[1];
+			const detergent2 = newItems[2];
+			const detergent3 = newItems[3];
+			expect(detergent1.prefab.id).toBe("DETERGENT");
+			expect(detergent2.prefab.id).toBe("DETERGENT");
+			expect(detergent3.prefab.id).toBe("EMPTY DETERGENT BOTTLE");
+			expect(detergent1.quantity).toBe(2);
+			expect(detergent2.quantity).toBe(1);
+			expect(detergent3.quantity).toBe(1);
+			expect(detergent1.uses).toBe(4);
+			expect(detergent2.uses).toBe(1);
+			expect(detergent3.uses).toBeNaN();
+		});
+
 		test('decrease uses of detergent in video room SINK 1 by 5', () => {
 			const sink = game.entityFinder.getFixture("SINK 1", "video-room");
 			const items = CollatedRoomItem.collate(getSortedItems(sink.getContainedItems()));
@@ -233,6 +275,44 @@ describe('CollatedRoomItem test', () => {
 			expect(detergent1.quantity).toBe(2);
 			expect(detergent2.quantity).toBe(2);
 			expect(detergent1.uses).toBe(4);
+			expect(detergent2.uses).toBeNaN();
+		});
+
+		test('decrease uses of detergent in video room SINK 1 by 6', () => {
+			const sink = game.entityFinder.getFixture("SINK 1", "video-room");
+			const items = CollatedRoomItem.collate(getSortedItems(sink.getContainedItems()));
+			const detergent = items[0];
+			detergent.decreaseUses(6);
+			const newItems = sink.getContainedItems();
+			expect(newItems).toHaveLength(4);
+			const detergent1 = newItems[1];
+			const detergent2 = newItems[2];
+			const detergent3 = newItems[3];
+			expect(detergent1.prefab.id).toBe("DETERGENT");
+			expect(detergent2.prefab.id).toBe("EMPTY DETERGENT BOTTLE");
+			expect(detergent3.prefab.id).toBe("DETERGENT");
+			expect(detergent1.quantity).toBe(1);
+			expect(detergent2.quantity).toBe(2);
+			expect(detergent3.quantity).toBe(1);
+			expect(detergent1.uses).toBe(3);
+			expect(detergent2.uses).toBeNaN();
+			expect(detergent3.uses).toBe(4);
+		});
+
+		test('decrease uses of detergent in video room SINK 1 by 7', () => {
+			const sink = game.entityFinder.getFixture("SINK 1", "video-room");
+			const items = CollatedRoomItem.collate(getSortedItems(sink.getContainedItems()));
+			const detergent = items[0];
+			detergent.decreaseUses(7);
+			const newItems = sink.getContainedItems();
+			expect(newItems).toHaveLength(3);
+			const detergent1 = newItems[1];
+			const detergent2 = newItems[2];
+			expect(detergent1.prefab.id).toBe("DETERGENT");
+			expect(detergent2.prefab.id).toBe("EMPTY DETERGENT BOTTLE");
+			expect(detergent1.quantity).toBe(2);
+			expect(detergent2.quantity).toBe(2);
+			expect(detergent1.uses).toBe(3);
 			expect(detergent2.uses).toBeNaN();
 		});
 
@@ -271,6 +351,44 @@ describe('CollatedRoomItem test', () => {
 			expect(detergent1.quantity).toBe(2);
 			expect(detergent2.quantity).toBe(2);
 			expect(detergent1.uses).toBe(2);
+			expect(detergent2.uses).toBeNaN();
+		});
+
+		test('decrease uses of detergent in video room SINK 1 by 10', () => {
+			const sink = game.entityFinder.getFixture("SINK 1", "video-room");
+			const items = CollatedRoomItem.collate(getSortedItems(sink.getContainedItems()));
+			const detergent = items[0];
+			detergent.decreaseUses(10);
+			const newItems = sink.getContainedItems();
+			expect(newItems).toHaveLength(4);
+			const detergent1 = newItems[1];
+			const detergent2 = newItems[2];
+			const detergent3 = newItems[3];
+			expect(detergent1.prefab.id).toBe("DETERGENT");
+			expect(detergent2.prefab.id).toBe("EMPTY DETERGENT BOTTLE");
+			expect(detergent3.prefab.id).toBe("DETERGENT");
+			expect(detergent1.quantity).toBe(1);
+			expect(detergent2.quantity).toBe(2);
+			expect(detergent3.quantity).toBe(1);
+			expect(detergent1.uses).toBe(1);
+			expect(detergent2.uses).toBeNaN();
+			expect(detergent3.uses).toBe(2);
+		});
+
+		test('decrease uses of detergent in video room SINK 1 by 11', () => {
+			const sink = game.entityFinder.getFixture("SINK 1", "video-room");
+			const items = CollatedRoomItem.collate(getSortedItems(sink.getContainedItems()));
+			const detergent = items[0];
+			detergent.decreaseUses(11);
+			const newItems = sink.getContainedItems();
+			expect(newItems).toHaveLength(3);
+			const detergent1 = newItems[1];
+			const detergent2 = newItems[2];
+			expect(detergent1.prefab.id).toBe("DETERGENT");
+			expect(detergent2.prefab.id).toBe("EMPTY DETERGENT BOTTLE");
+			expect(detergent1.quantity).toBe(2);
+			expect(detergent2.quantity).toBe(2);
+			expect(detergent1.uses).toBe(1);
 			expect(detergent2.uses).toBeNaN();
 		});
 

--- a/Test/Data/CollatedRoomItem.test.js
+++ b/Test/Data/CollatedRoomItem.test.js
@@ -193,9 +193,9 @@ describe('CollatedRoomItem test', () => {
 			expect(detergent1.quantity).toBe(2);
 			expect(detergent2.quantity).toBe(1);
 			expect(detergent3.quantity).toBe(1);
-			expect(detergent1.quantity).toBe(2);
-			expect(detergent2.quantity).toBe(1);
-			expect(detergent3.quantity).toBe(1);
+			expect(detergent1.uses).toBe(4);
+			expect(detergent2.uses).toBe(3);
+			expect(detergent3.uses).toBe(1);
 		});
 
 		test('decrease uses of detergent in video room SINK 1 by 2', () => {
@@ -242,19 +242,19 @@ describe('CollatedRoomItem test', () => {
 			const detergent = items[0];
 			detergent.decreaseUses(8);
 			const newItems = sink.getContainedItems();
-			expect(newItems).toHaveLength(4);
+			expect(newItems).toHaveLength (4);
 			const detergent1 = newItems[1];
 			const detergent2 = newItems[2];
 			const detergent3 = newItems[3];
 			expect(detergent1.prefab.id).toBe("DETERGENT");
-			expect(detergent2.prefab.id).toBe("DETERGENT");
-			expect(detergent3.prefab.id).toBe("EMPTY DETERGENT BOTTLE");
+			expect(detergent2.prefab.id).toBe("EMPTY DETERGENT BOTTLE");
+			expect(detergent3.prefab.id).toBe("DETERGENT");
 			expect(detergent1.quantity).toBe(1);
-			expect(detergent2.quantity).toBe(1);
-			expect(detergent3.quantity).toBe(2);
-			expect(detergent1.uses).toBe(4);
-			expect(detergent2.uses).toBe(1);
-			expect(detergent3.uses).toBeNaN();
+			expect(detergent2.quantity).toBe(2);
+			expect(detergent3.quantity).toBe(1);
+			expect(detergent1.uses).toBe(2);
+			expect(detergent2.uses).toBeNaN();
+			expect(detergent3.uses).toBe(3);
 		});
 
 		test('decrease uses of detergent in video room SINK 1 by 9', () => {
@@ -269,7 +269,7 @@ describe('CollatedRoomItem test', () => {
 			expect(detergent1.prefab.id).toBe("DETERGENT");
 			expect(detergent2.prefab.id).toBe("EMPTY DETERGENT BOTTLE");
 			expect(detergent1.quantity).toBe(2);
-			expect(detergent2.quantity).toBe(1);
+			expect(detergent2.quantity).toBe(2);
 			expect(detergent1.uses).toBe(2);
 			expect(detergent2.uses).toBeNaN();
 		});
@@ -286,7 +286,7 @@ describe('CollatedRoomItem test', () => {
 			expect(detergent1.prefab.id).toBe("DETERGENT");
 			expect(detergent2.prefab.id).toBe("EMPTY DETERGENT BOTTLE");
 			expect(detergent1.quantity).toBe(1);
-			expect(detergent2.quantity).toBe(2);
+			expect(detergent2.quantity).toBe(3);
 			expect(detergent1.uses).toBe(1);
 			expect(detergent2.uses).toBeNaN();
 		});
@@ -300,7 +300,7 @@ describe('CollatedRoomItem test', () => {
 			expect(newItems).toHaveLength(2);
 			const newDetergent = newItems[1];
 			expect(newDetergent.prefab.id).toBe("EMPTY DETERGENT BOTTLE");
-			expect(newDetergent.quantity).toBe(3);
+			expect(newDetergent.quantity).toBe(4);
 			expect(newDetergent.uses).toBeNaN();
 		});
 	});

--- a/Test/Data/CollatedRoomItem.test.js
+++ b/Test/Data/CollatedRoomItem.test.js
@@ -242,7 +242,7 @@ describe('CollatedRoomItem test', () => {
 			const detergent = items[0];
 			detergent.decreaseUses(8);
 			const newItems = sink.getContainedItems();
-			expect(newItems).toHaveLength (4);
+			expect(newItems).toHaveLength(4);
 			const detergent1 = newItems[1];
 			const detergent2 = newItems[2];
 			const detergent3 = newItems[3];


### PR DESCRIPTION
Hello! This PR introduces my own implementation of `CollatedRoomItem.decreaseUses()`, which passes all tests with mathematical correctness, and a few small caveats. I will detail those caveats below:
* Test `CollatedRoomItem test.test decreaseUses method.decrease uses of detergent in video room SINK 1 by 1` now expects the mathematically correct number of remaining usages, rather than expecting the mathematically correct number of quantities a second time.
* Test `CollatedRoomItem test.test decreaseUses method.decrease uses of detergent in video room SINK 1 by 8` needed reordering of expected items, and tweaks to the exact expected values. Quantity and uses add up to be the same as before.
* To abide by the law of conservation of matter, test `CollatedRoomItem test.test decreaseUses method.decrease uses of detergent in video room SINK 1 by 9` now expects there to be two empty detergent bottles (and two usable detergent bottles, with a total remaining use count of 4).
* To abide by the law of conservation of matter, test `CollatedRoomItem test.test decreaseUses method.decrease uses of detergent in video room SINK 1 by 12` now expects there to be three empty detergent bottles (and one usable detergent bottles, with a total remaining use count of 1).
* To abide by the law of conservation of matter, test `CollatedRoomItem test.test decreaseUses method.decrease uses of detergent in video room SINK 1 by 13` now expects there to be four empty detergent bottles (and zero usable detergent bottles).

Please carefully review changed logic and implications thereof.
—❄️