### PR TITLE
Extend .gitignore to ignore .zed project settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -281,6 +281,8 @@ paket-files/
 __pycache__/
 *.pyc
 
+# Zed Text Editor
+.zed/
 
 convert.js
 convertedText.txt


### PR DESCRIPTION
Hello! This PR extends `.gitignore` to ignore project-specific settings for [Zed](https://zed.dev).
—❄️