### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,212 @@
+<!--
+SPDX-FileCopyrightText: The Django Project <django.org>
+SPDX-FileCopyrightText: Python Software Foundation <python.org>
+SPDX-FileCopyrightText: 2014 Speak Up! <speakup.io>
+SPDX-FileCopyrightText: 2017 Stumptown Syndicate <stumptownsyndicate.org>
+SPDX-FileCopyrightText: 2017 Sage Sharp <sharp@otter.technology>
+SPDX-FileCopyrightText: 2017 Organization for Ethical Source <contributor-covenant.org>
+SPDX-FileCopyrightText: 2019 The Carpentries <carpentries.org>
+SPDX-FileCopyrightText: 2020 Mozilla <mozilla.org>
+SPDX-FileCopyrightText: 2025 GNOME Code of Conduct Committee <conduct.gnome.org>
+SPDX-FileCopyrightText: 2026 Fedora Project <fedoraproject.org>
+SPDX-FileCopyrightText: 2026 Amy Poon <amy@amypoon.me>
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Alter Ego Code of Conduct
+
+Thank you for being a part of the Alter Ego project. We value your participation and want everyone to have an enjoyable
+and fulfilling experience. Accordingly, all participants are expected to follow this Code of Conduct, and to show
+respect, understanding, and consideration to one another. Thank you for helping make this a welcoming, friendly
+community for everyone.
+
+If you witness or experience any behavior that violates our Code of Conduct, please do not hesitate to report it to our
+maintainers. Together, let’s ensure a safe and inclusive environment for all members.
+
+## Scope
+
+This Code of Conduct applies to all Alter Ego community spaces, including, but not limited to:
+
+- Documentation and tutorials - MsVBLANK.github.io/Alter-Ego
+- Code repositories - github.com/MsVBLANK/Alter-Ego
+- Chat and forums - GitHub Discussions, Alter Ego Help Discord
+- Any other channels or groups which exist in order to discuss Alter Ego project activities
+
+Communication channels and private conversations that are normally out of scope may be considered in scope if a
+Alter Ego participant is being stalked or harassed. Social media conversations may be considered in-scope if the
+incident occurred under an Alter Ego event hashtag, or when an official Alter Ego account on social media is tagged, or
+within any other discussion about Alter Ego. Alter Ego maintainers reserve the right to take actions against
+behaviors that happen in any context, if they are deemed to be relevant to the Alter Ego project and its participants.
+
+All participants in Alter Ego community spaces are subject to the Code of Conduct. This includes maintainers, contributors, contribution reviewers, issue reporters, Alter Ego users, and anyone participating in discussion in
+Alter Ego community spaces.
+
+## Reporting an Incident
+
+If you believe that someone is violating the Code of Conduct, or have any other concerns, please contact the Code of Conduct committee.
+
+## Our Standards
+
+The Alter Ego community is dedicated to providing a positive experience for everyone, regardless of:
+
+- age
+- body size
+- caste
+- citizenship
+- disability
+- education
+- ethnicity
+- familial status
+- gender expression
+- gender identity
+- genetic information
+- immigration status
+- level of experience
+- nationality
+- personal appearance
+- pregnancy
+- race
+- religion
+- sex characteristics
+- sexual orientation
+- sexual identity
+- socio-economic status
+- tribe
+
+### Community Guidelines
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Be friendly. Use welcoming and inclusive language.
+- Be empathetic. Be respectful of differing viewpoints and experiences.
+- Be respectful. When we disagree, we do so in a polite and constructive manner.
+- Be considerate. Remember that decisions are often a difficult choice between competing priorities. Focus on what is
+  best for the community. Keep discussions around technology choices constructive and respectful.
+- Be patient and generous. If someone asks for help it is because they need it. When documentation is available that
+  answers the question, politely point them to it. If the question is off-topic, suggest a more appropriate online
+  space to seek help.
+- Try to be concise. Read the discussion before commenting in order to not repeat a point that has been made.
+
+### Inappropriate Behavior
+
+Community members asked to stop any inappropriate behavior are expected to comply immediately.
+
+We want all participants in the Alter Ego community to have the best possible experience they can. In order to be clear
+what that means, we've provided a list of examples of behaviors that are inappropriate for Alter Ego community spaces:
+
+- Deliberate intimidation, stalking, or following.
+- Sustained disruption of online discussion, talks, or other events. Sustained disruption of events, online
+  discussions, or meetings, will not be tolerated.
+- Sexist, racist, homophobic, transphobic, ableist language or otherwise exclusionary language. This includes
+  deliberately referring to someone by a gender that they do not identify with, and/or questioning the legitimacy of an
+  individual's gender identity. If you're unsure if a word is derogatory, don't use it. This also includes repeated
+  subtle and/or indirect discrimination.
+- Unwelcome sexual attention or behavior that contributes to a sexualized environment. This includes sexualized
+  comments, jokes or imagery in interactions, communications or presentation materials, as well as inappropriate
+  touching, groping, or sexual advances.
+- Unwelcome physical contact. This includes touching a person without permission, including sensitive areas such as
+  their hair, pregnant stomach, mobility device (wheelchair, scooter, etc) or tattoos. This also includes physically
+  blocking or intimidating another person. Physical contact or simulated physical contact (such as emojis like "kiss")
+  without affirmative consent is not acceptable. This includes sharing or distribution of sexualized images or text.
+- Violence or threats of violence. Violence and threats of violence are not acceptable - online or offline. This
+  includes incitement of violence toward any individual, including encouraging a person to commit self-harm. This also
+  includes posting or threatening to post other people's personally identifying information ("doxxing") online.
+- Influencing or encouraging inappropriate behavior. If you influence or encourage another person to violate the Code
+  of Conduct, you may face the same consequences as if you had violated the Code of Conduct.
+
+### Safety versus Comfort
+
+The Alter Ego community prioritizes marginalized people's safety over privileged people's comfort, for example in situations involving:
+
+- Reverse"-isms, including "reverse racism," "reverse sexism," and "cisphobia"
+- Reasonable communication of boundaries, such as "leave me alone," "go away," or "I'm not discussing this with you."
+- Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
+- Communicating boundaries or criticizing oppressive behavior in a "tone" you don't find congenial
+
+The examples listed above are not against the Code of Conduct. If you have questions about the above statements, please
+read the "Supporting Diversity" section below.
+
+Basic expectations for conduct are not covered by the "reverse-ism clause" and would be enforced irrespective of the
+demographics of those involved. For example, racial discrimination will not be tolerated, irrespective of the race of
+those involved. Nor would unwanted sexual attention be tolerated, whatever someone's gender or sexual orientation.
+Members of our community have the right to expect that participants in the project will uphold these standards.
+
+If a participant engages in behavior that violates this code of conduct, Alter Ego maintainers may take any action they
+deem appropriate. Examples of consequences are outlined in the Committee Procedures Guide.
+
+### Supporting Diversity
+
+The Alter Ego project values diversity. If you are new to conversations about diversity, here are our guidelines for supporting marginalized groups in our community:
+
+1. Acknowledge that the lived experiences of marginalized groups are valid. We acknowledge that each community member
+   will experience the world differently, based on their past experiences, background and identity. We encourage you to
+   bring your experiences to community conversations, while being open to learning about other people's different lived
+   experiences.
+2. Process intense feelings about diversity with a friend. If you have never experienced discrimination, learning about
+   it may make you feel uncomfortable, upset, or even angry. You may feel sad because you didn't realize the world was
+   unjust. You may feel guilty because you hold unconscious bias. You may feel excluded because your experiences with
+   hardship are not viewed as discrimination. We encourage you process those feelings with a person with a similar
+   background who understands the discrimination marginalized groups in our community face.
+3. Listen to marginalized groups, but try not to put the burden of education on them. We encourage community members to
+   be curious about different lived experiences. However, note that people from marginalized groups in our community
+   are often asked to explain their experiences. Providing education and examples of discrimination can be emotionally
+   draining. We ask that community members to do their own research before asking for education from marginalized
+   groups in our community. If a community member does not want to discuss a diversity topic with you, please respect
+   their wishes. Reasonable communication of topic boundaries is not against the Code of Conduct.
+4. Be open to learning how to be more inclusive. It's important that our community talk about how to become more
+   inclusive. If you see behavior that is discriminatory, we encourage you to report it to the Code of Conduct
+   committee. We also recognize that community members may chose to privately or publicly critique behavior that
+   negatively impacts marginalized groups in our community. It is not against the Code of Conduct to provide such a
+   critique.
+5. Avoid critiquing people's tone when they talk about discrimination. Talking about discrimination and different lived
+   experiences can be difficult. Seeing biased or discriminatory statements can bring up past negative experiences for
+   marginalized groups in our community. These negative experiences often bring up strong emotions, which may lead to
+   the person communicating in a more blunt tone. We encourage community members to acknowledge others' experiences
+   with discrimination, rather than critiquing the tone that people use to communicate about that discrimination.
+6. Understand creating an inclusive culture takes time, energy, and resources. The Alter Ego project acknowledges that
+   discrimination, harassment, unconscious bias, and systemic inequality exists. Because of this, people from
+   marginalized groups in our community may have less access to resources or opportunities. It is important for our
+   community to take action and correct these issues. All community change requires resources (such as time, influence,
+   or money). We acknowledge that such resources will be spent towards correcting past bias and discrimination.
+
+<!--TODO: Figure this out-->
+## Procedure for Handling Incidents
+
+    Reporter Guide
+
+    Moderator Procedures
+
+    Committee Procedures Guide
+
+## License
+
+The Alter Ego Code of Conduct is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License].
+
+## Attribution
+
+<!--TODO: List everything from the GNOME COC-->
+
+The Alter Ego Code of Conduct is based on the [GNOME Code of Conduct](https://conduct.gnome.org/), which is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License].
+
+The above section [Supporting Diversity](https://conduct.gnome.org/supporting-diversity/) is licensed under the [Creative Commons Attribution 3.0 Unported License] by Sage Sharp of Otter Tech.
+
+Additional language was incorporated and modified from the following Codes of Conduct:
+
+- [Citizen Code of Conduct](https://web.archive.org/web/20250705070629/https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md) is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License]
+- [Code of Conduct template](https://github.com/sagesharp/code-of-conduct-template/) is licensed under a [Creative Commons Attribution 3.0 Unported License] by Otter Tech
+- [Contributor Covenant version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct) is licensed under a [Creative Commons Attribution 4.0 International License]
+- [Data Carpentry Code of Conduct](https://docs.carpentries.org/policies/coc) is licensed [Creative Commons Attribution 4.0 International License]
+- [Django Project Code of Conduct](https://www.djangoproject.com/conduct/) is licensed under a [Creative Commons Attribution 3.0 Unported License]
+- [Fedora Code of Conduct](https://docs.fedoraproject.org/en-US/project/code-of-conduct/) is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License]
+- [Geek Feminism Anti-harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) which is under a [Creative Commons Zero License]
+- [LGBTQ in Technology Slack Code of Conduct](https://lgbtq.technology/coc.html) licensed under a [Creative Commons Zero License]
+- [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/) is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License]
+- [Python Mentors Code of Conduct](https://www.python.org/dev/core-mentorship)
+- [Speak Up! Community Code of Conduct](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html) is licensed under a [Creative Commons Attribution 3.0 Unported License]
+
+[Creative Commons Attribution-ShareAlike 3.0 Unported License]: https://creativecommons.org/licenses/by-sa/3.0/
+[Creative Commons Attribution 3.0 Unported License]: https://creativecommons.org/licenses/by/3.0/
+[Creative Commons Attribution-ShareAlike 4.0 International License]: https://creativecommons.org/licenses/by-sa/4.0/
+[Creative Commons Zero License]: https://creativecommons.org/licenses/zero/1.0/
+[Creative Commons Attribution 4.0 International License]: https://creativecommons.org/licenses/by/4.0/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -170,22 +170,15 @@ The Alter Ego project values diversity. If you are new to conversations about di
    community to take action and correct these issues. All community change requires resources (such as time, influence,
    or money). We acknowledge that such resources will be spent towards correcting past bias and discrimination.
 
-<!--TODO: Figure this out-->
 ## Procedure for Handling Incidents
 
-    Reporter Guide
-
-    Moderator Procedures
-
-    Committee Procedures Guide
+<!--TODO: Figure this out-->
 
 ## License
 
 The Alter Ego Code of Conduct is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License].
 
 ## Attribution
-
-<!--TODO: List everything from the GNOME COC-->
 
 The Alter Ego Code of Conduct is based on the [GNOME Code of Conduct](https://conduct.gnome.org/), which is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License].
 


### PR DESCRIPTION
This PR adds a Code of Conduct to the project based on the [GNOME Code of Conduct](https://conduct.gnome.org/).

To adapt it, we need to remove any things that do not apply to AE (in-person events, talks etc.), and add our own procedures and other things.