### PR TITLE
Enable left handedness

### DIFF
--- a/Classes/GameEntityFinder.ts
+++ b/Classes/GameEntityFinder.ts
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2019 Alter Ego Contributors
+// SPDX-FileCopyrightText: 2026 LavCorps <lavcorps@protonmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -205,6 +206,8 @@ export default class GameEntityFinder {
 		let hands: EquipmentSlot[] = [];
 		if (player.inventory.has("RIGHT HAND")) hands.push(player.inventory.get("RIGHT HAND"));
 		if (player.inventory.has("LEFT HAND")) hands.push(player.inventory.get("LEFT HAND"));
+        // Right-biased handedness may not be desirable. This sorting function allows for players to have a left hand used for handed operations by default, with a trivial computational cost.
+        hands.sort((a, b) => a.row - b.row);
 		return hands;
 	}
 

--- a/Data/Player.ts
+++ b/Data/Player.ts
@@ -771,23 +771,20 @@ export default class Player extends RecipeProcessor implements PersistentGameEnt
      * Creates a string of non-discreet inventory items in the player's hands.
      */
     createMoveAppendString(): string {
+        // Get the player's held items, sorted by size.
+        const heldItems = this.getGame().entityFinder.getPlayerHands(this)
+            .filter(hand => hand.equippedItem !== null && !hand.equippedItem.prefab.discreet)
+            .map(hand => hand.equippedItem)
+            .toSorted((a, b) => b.size - a.size);
+        const collatedHeldItems = CollatedItem.collateForItemList(heldItems);
+
         let nonDiscreetItems: string[] = [];
-        const hands = this.getGame().entityFinder.getPlayerHands(this);
-        for (const hand of hands)
-            if (hand.equippedItem !== null && !hand.equippedItem.prefab.discreet)
-                nonDiscreetItems.push(hand.equippedItem.singleContainingPhrase);
+        for (const heldItem of collatedHeldItems)
+            nonDiscreetItems.push(heldItem.toSingleOrPluralContainingPhrase());
 
         let appendString = "";
-        /**
-         * @privateRemarks
-         * I am of the understanding that this function shall soon be refactored regardless,
-         * so I will not touch any further in service to the `feature/handedness` PR, but I do wish to point out that
-         * if a player has more than two hands, this will be insufficient.
-         */
-        if (nonDiscreetItems.length === 1)
-            appendString = ` carrying ${nonDiscreetItems[0]}`;
-        else if (nonDiscreetItems.length === 2)
-            appendString = ` carrying ${nonDiscreetItems[0]} and ${nonDiscreetItems[1]}`;
+        if (nonDiscreetItems.length > 0)
+            appendString = ` carrying ${generateListString(nonDiscreetItems)}`;
 
         return appendString;
     }

--- a/Data/Player.ts
+++ b/Data/Player.ts
@@ -772,14 +772,18 @@ export default class Player extends RecipeProcessor implements PersistentGameEnt
      */
     createMoveAppendString(): string {
         let nonDiscreetItems: string[] = [];
-        const rightHand = this.inventory.get("RIGHT HAND");
-        if (rightHand && rightHand.equippedItem !== null && !rightHand.equippedItem.prefab.discreet)
-            nonDiscreetItems.push(rightHand.equippedItem.singleContainingPhrase);
-        const leftHand = this.inventory.get("LEFT HAND");
-        if (leftHand && leftHand.equippedItem !== null && !leftHand.equippedItem.prefab.discreet)
-            nonDiscreetItems.push(leftHand.equippedItem.singleContainingPhrase);
+        const hands = this.getGame().entityFinder.getPlayerHands(this);
+        for (const hand of hands)
+            if (hand.equippedItem !== null && !hand.equippedItem.prefab.discreet)
+                nonDiscreetItems.push(hand.equippedItem.singleContainingPhrase);
 
         let appendString = "";
+        /**
+         * @privateRemarks
+         * I am of the understanding that this function shall soon be refactored regardless,
+         * so I will not touch any further in service to the `feature/handedness` PR, but I do wish to point out that
+         * if a player has more than two hands, this will be insufficient.
+         */
         if (nonDiscreetItems.length === 1)
             appendString = ` carrying ${nonDiscreetItems[0]}`;
         else if (nonDiscreetItems.length === 2)


### PR DESCRIPTION
Hello! This extremely simple PR introduces a sort on `GEF.getPlayerHands()` to sort by row ID. I believe this should break the right-by-default behavior of handedness in current Alter Ego, so long as the left hand is above the right hand on the data sheet.
—❄️