### PR TITLE
Synchronous ActionDirective Generation

### DIFF
--- a/Classes/ActionDirective.ts
+++ b/Classes/ActionDirective.ts
@@ -1,75 +1,79 @@
+// SPDX-FileCopyrightText: 2026 Ms. VBLANK <alteregomolly@pm.me>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import Action from "../Data/Action.ts";
 import type Game from "../Data/Game.ts";
 import type Player from "../Data/Player.ts";
 import type Room from "../Data/Room.ts";
 import type Whisper from "../Data/Whisper.ts";
-import { subtle } from "crypto";
+import { createHash } from "crypto";
 
 /**
  * Represents an action to perform when a Discord Interaction is executed.
  */
 export default class ActionDirective<T extends Action = Action> {
-	/**
-	 * The action this directive should create.
-	 */
-	readonly action: { new(...args: any[]): T };
+    /**
+     * The action this directive should create.
+     */
+    readonly action: { new(...args: any[]): T };
     /**
      * The player the action should be constructed with by default.
      */
     readonly #player: Player;
-	/**
-	 * The raw arguments provided for this action.
-	 */
-	readonly #args: string[];
-	customId: string;
+    /**
+     * The raw arguments provided for this action.
+     */
+    readonly #args: string[];
+    /**
+     * A custom ID for this action directive based on its action and arguments.
+     * This is used to identify the action directive when an interaction is received.
+     */
+    readonly customId: string;
 
-	/**
-	 * @param action - The action this directive should create.
+    /**
+     * @param action - The action this directive should create.
      * @param player - The player the action should be constructed with by default.
-	 * @param args - The raw arguments provided for this action. These will be used to generate the custom ID, and will be passed to the action's perform function.
-	 * @throws {TypeError} If the provided action is not a subclass of Action.
-	 */
-	constructor(action: T, player: Player, args: any[]) {
-		this.action = action.constructor as { new(...args: any[]): T };
+     * @param args - The raw arguments provided for this action. These will be used to generate the custom ID, and will be passed to the action's perform function.
+     * @param user - The user this directive is being generated for. This is included in the hash to ensure that directives generated for different user with the same action and arguments will have different custom IDs, preventing conflicts.
+     * @throws {TypeError} If the provided action is not a subclass of Action.
+     */
+    constructor(action: T, player: Player, args: any[], user: User) {
+        this.action = action.constructor as { new(...args: any[]): T };
         this.#player = player;
-		this.#args = args;
-	}
+        this.#args = args;
+        this.customId = this.#generateCustomId(user);
+    }
 
-	/**
-	 * Generates a custom ID for this action directive based on its action and arguments. This is used to identify the directive when an interaction is received.
-	 * @param user - The user this directive is being generated for. This is included in the hash to ensure that directives generated for different user with the same action and arguments will have different custom IDs, preventing conflicts.
-	 */
-	async generateCustomId(user: User) {
-		const buffer = new TextEncoder().encode([user.id].concat(this.#args).join(","));
-		const hashBuffer = await subtle.digest("SHA-256", buffer);
-		const hashArray = Array.from(new Uint8Array(hashBuffer));
-		const hashHex = hashArray.map(b => b.toString(16).padStart(2, "0")).join("");
-		return `${this.action.name}:${hashHex}`;
-	}
+    /**
+     * Generates a custom ID for this action directive based on its action and arguments. This is used to identify the directive when an interaction is received.
+     * @param user - The user this directive is being generated for. This is included in the hash to ensure that directives generated for different user with the same action and arguments will have different custom IDs, preventing conflicts.
+     */
+    #generateCustomId(user: User) {
+        const input = [user.id].concat(this.#args).join(",");
+        const hashHex = createHash("sha256").update(input).digest("hex");
+        return `${this.action.name}:${hashHex}`;
+    }
 
-	setCustomId(customId: string) {
-		this.customId = customId;
-	}
-
-	/**
-	 * Creates an instance of the given action.
-	 * @param game - The game this belongs to.
-	 * @param message - The message that initiated the action.
-	 * @param player - The player performing the action.
-	 * @param location - The location where this action is being performed.
-	 * @param forced - Whether or not the action was performed by someone other than the player themselves.
-	 * @param whisper - The whisper where this action is being performed, if applicable.
+    /**
+     * Creates an instance of the given action.
+     * @param game - The game this belongs to.
+     * @param message - The message that initiated the action.
+     * @param player - The player performing the action.
+     * @param location - The location where this action is being performed.
+     * @param forced - Whether or not the action was performed by someone other than the player themselves.
+     * @param whisper - The whisper where this action is being performed, if applicable.
      * @param user - The user who created the action, if applicable.
-	 */
-	createAction(game: Game, message: UserMessage, player: Player, location: Room, forced: boolean, whisper?: Whisper, user?: User) {
-		return new this.action(game, message, player, location, forced, whisper, user);
-	}
+     */
+    createAction(game: Game, message: UserMessage, player: Player, location: Room, forced: boolean, whisper?: Whisper, user?: User) {
+        return new this.action(game, message, player, location, forced, whisper, user);
+    }
 
     getPlayerName() {
         return this.#player?.name;
     }
 
-	getArgs() {
-		return this.#args;
-	}
+    getArgs() {
+        return this.#args;
+    }
 }

--- a/Classes/ClientInteractableManager.ts
+++ b/Classes/ClientInteractableManager.ts
@@ -72,6 +72,8 @@ interface InteractableMessage {
     messageId: Snowflake;
 }
 
+type ButtonOrStringSelectMenuInteractable = ButtonInteractable | StringSelectMenuInteractable;
+
 /**
  * A set of functions for creating and managing Interactables.
  */
@@ -190,11 +192,8 @@ export default class ClientInteractableManager {
      * @param player - The player this action directive is being created for.
      * @param user - The user this action directive is being created for. This is used to generate a unique custom ID for the directive, preventing conflicts with directives created for other users with the same action and arguments.
      */
-    async #createActionDirective<T extends Action>(actionClass: { new(...args: any[]): T }, args: any[], player: Player, user: User): Promise<ActionDirective<T>> {
-        const actionDirective = new ActionDirective(actionClass.prototype, player, args);
-        const customId = await actionDirective.generateCustomId(user);
-        actionDirective.setCustomId(customId);
-        return actionDirective;
+    #createActionDirective<T extends Action>(actionClass: { new(...args: any[]): T }, args: any[], player: Player, user: User): ActionDirective<T> {
+        return new ActionDirective(actionClass.prototype, player, args, user);
     }
 
     /**
@@ -265,17 +264,17 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for. This is used to determine which exits the player can use.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createQueueMoveActionInteractables(exits: Exit[], player: Player, user: User = player): Promise<ButtonInteractable[]> {
+    createQueueMoveActionInteractables(exits: Exit[], player: Player, user: User = player): ButtonInteractable[] {
         const moveButtons: ButtonInteractable[] = [];
         const runButtons: ButtonInteractable[] = [];
         for (const exit of exits) {
             if (player.canUseCommand("move")) {
-                const actionDirective = await this.#createActionDirective(QueueMoveAction, exit.getQueueMoveActionDirectiveArgs(player.location, false), player, user);
+                const actionDirective = this.#createActionDirective(QueueMoveAction, exit.getQueueMoveActionDirectiveArgs(player.location, false), player, user);
                 const buttonOptions = new InteractableOptions(actionDirective, `Move ${exit.name}`);
                 moveButtons.push(this.#createButtonInteractable(buttonOptions, ButtonStyle.Primary, ActionPriority.QUEUE_MOVE));
             }
             if (player.canUseCommand("run")) {
-                const actionDirective = await this.#createActionDirective(QueueMoveAction, exit.getQueueMoveActionDirectiveArgs(player.location, true), player, user);
+                const actionDirective = this.#createActionDirective(QueueMoveAction, exit.getQueueMoveActionDirectiveArgs(player.location, true), player, user);
                 const buttonOptions = new InteractableOptions(actionDirective, `Run ${exit.name}`);
                 runButtons.push(this.#createButtonInteractable(buttonOptions, ButtonStyle.Danger, ActionPriority.QUEUE_RUN));
             }
@@ -288,9 +287,9 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createStopActionInteractable(player: Player, user: User = player): Promise<ButtonInteractable[]> {
+    createStopActionInteractable(player: Player, user: User = player): ButtonInteractable[] {
         if (!player.canUseCommand("stop")) return [];
-        const actionDirective = await this.#createActionDirective(StopAction, [], player, user);
+        const actionDirective = this.#createActionDirective(StopAction, [], player, user);
         const interactableOptions = new InteractableOptions(actionDirective, `Stop`);
         return [this.#createButtonInteractable(interactableOptions, ButtonStyle.Danger, ActionPriority.STOP)];
     }
@@ -301,11 +300,11 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createInspectActionInteractable(entities: Inspectable[], player: Player, user: User = player): Promise<StringSelectMenuInteractable[]> {
+    createInspectActionInteractable(entities: Inspectable[], player: Player, user: User = player): StringSelectMenuInteractable[] {
         if (!player.canUseCommand("inspect")) return [];
         const interactableOptions: InteractableOptions<InspectAction>[] = [];
         for (const entity of entities) {
-            const actionDirective = await this.#createActionDirective(InspectAction, entity.getInspectActionDirectiveArgs(), player, user);
+            const actionDirective = this.#createActionDirective(InspectAction, entity.getInspectActionDirectiveArgs(), player, user);
             const label = entity instanceof Player ? entity.displayName : entity.name;
             const containerString = entity instanceof ItemInstance && entity.container ?
                 entity.container instanceof ItemInstance && entity.container.inventory.size > 1 ?
@@ -315,7 +314,7 @@ export default class ClientInteractableManager {
             const description = `Inspect ${label}${containerString}`;
             interactableOptions.push(new InteractableOptions(actionDirective, label, label, description));
         }
-        const actionDirective = await this.#createActionDirective(InspectAction, ["InspectAction Menu"], player, user);
+        const actionDirective = this.#createActionDirective(InspectAction, ["InspectAction Menu"], player, user);
         return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Inspect", ActionPriority.INSPECT);
     }
 
@@ -325,11 +324,11 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createTakeActionInteractable(entities: RoomItem[], player: Player, user: User = player): Promise<(ButtonInteractable | StringSelectMenuInteractable)[]> {
+    createTakeActionInteractable(entities: RoomItem[], player: Player, user: User = player): ButtonOrStringSelectMenuInteractable[] {
         if (!player.canUseCommand("take")) return [];
         const interactableOptions: InteractableOptions<TakeAction>[] = [];
         for (const entity of entities) {
-            const actionDirective = await this.#createActionDirective(TakeAction, entity.getTakeActionDirectiveArgs(), player, user);
+            const actionDirective = this.#createActionDirective(TakeAction, entity.getTakeActionDirectiveArgs(), player, user);
             const containerString = entity.container instanceof RoomItem && entity.container.inventory.size > 1 ?
                 ` from ${entity.slot} of ${entity.container.name}`
                 : ` from ${entity.container.name}`;
@@ -339,7 +338,7 @@ export default class ClientInteractableManager {
             interactableOptions.push(new InteractableOptions(actionDirective, buttonLabel, stringSelectLabel, description));
         }
         if (interactableOptions.length > 2) {
-            const actionDirective = await this.#createActionDirective(TakeAction, ["TakeAction Menu"], player, user);
+            const actionDirective = this.#createActionDirective(TakeAction, ["TakeAction Menu"], player, user);
             return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Take", ActionPriority.TAKE);
         }
         else return this.#createButtonInteractables(interactableOptions, ButtonStyle.Primary, ActionPriority.TAKE);
@@ -352,7 +351,7 @@ export default class ClientInteractableManager {
      * @param container - The fixture or room item the player is dropping the items into.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createDropActionInteractables(entities: InventoryItem[], player: Player, container: RoomItemContainer, user: User = player): Promise<(ButtonInteractable | StringSelectMenuInteractable)[]> {
+    createDropActionInteractables(entities: InventoryItem[], player: Player, container: RoomItemContainer, user: User = player): ButtonOrStringSelectMenuInteractable[] {
         if (!player.canUseCommand("drop")) return [];
         const interactableOptions: InteractableOptions<DropAction>[] = [];
         for (const entity of entities) {
@@ -361,7 +360,7 @@ export default class ClientInteractableManager {
             if (container instanceof RoomItem && container.inventory.size > 1) {
                 for (const inventorySlot of container.inventory.values()) {
                     if (inventorySlot.willBeOverFilledBy(entity)) continue;
-                    const actionDirective = await this.#createActionDirective(DropAction, entity.getDropActionDirectiveArgs(containerType, container, inventorySlot), player, user);
+                    const actionDirective = this.#createActionDirective(DropAction, entity.getDropActionDirectiveArgs(containerType, container, inventorySlot), player, user);
                     const stringSelectLabel = `${entity.name} ${container.getPreposition()} ${inventorySlot.id}`;
                     const description = `Drop ${entity.name} ${container.getPreposition()} ${inventorySlot.id} of ${container.name}`;
                     interactableOptions.push(new InteractableOptions(actionDirective, buttonLabel, stringSelectLabel, description));
@@ -370,14 +369,14 @@ export default class ClientInteractableManager {
             else {
                 const inventorySlot = container instanceof RoomItem ? container.inventory.first() : undefined;
                 if (inventorySlot && inventorySlot.willBeOverFilledBy(entity)) continue;
-                const actionDirective = await this.#createActionDirective(DropAction, entity.getDropActionDirectiveArgs(containerType, container, inventorySlot), player, user);
+                const actionDirective = this.#createActionDirective(DropAction, entity.getDropActionDirectiveArgs(containerType, container, inventorySlot), player, user);
                 const stringSelectLabel = `${entity.name} ${container.getPreposition()} ${container.name}`;
                 const description = `Drop ${entity.name} ${container.getPreposition()} ${container.name}`;
                 interactableOptions.push(new InteractableOptions(actionDirective, buttonLabel, stringSelectLabel, description));
             }
         }
         if (interactableOptions.length > 2) {
-            const actionDirective = await this.#createActionDirective(DropAction, ["DropAction Menu"], player, user);
+            const actionDirective = this.#createActionDirective(DropAction, ["DropAction Menu"], player, user);
             return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Drop", ActionPriority.DROP);
         }
         else return this.#createButtonInteractables(interactableOptions, ButtonStyle.Primary, ActionPriority.DROP);
@@ -390,7 +389,7 @@ export default class ClientInteractableManager {
      * @param viableContainers - A map of viable stash containers to the inventory slots the item can be stashed into. This is used to determine which stash options to create for each item.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createStashActionInteractables(entities: InventoryItem[], player: Player, viableContainers: Map<InventoryItem, string[]>, user: User = player): Promise<(ButtonInteractable | StringSelectMenuInteractable)[]> {
+    createStashActionInteractables(entities: InventoryItem[], player: Player, viableContainers: Map<InventoryItem, string[]>, user: User = player): ButtonOrStringSelectMenuInteractable[] {
         if (!player.canUseCommand("stash")) return [];
         const interactableOptions: InteractableOptions<StashAction>[] = [];
         for (const entity of entities) {
@@ -399,7 +398,7 @@ export default class ClientInteractableManager {
                 for (const inventorySlotId of inventorySlots) {
                     const inventorySlot = container.inventory.get(inventorySlotId);
                     if (!inventorySlot || inventorySlot.willBeOverFilledBy(entity)) continue;
-                    const actionDirective = await this.#createActionDirective(StashAction, entity.getStashActionDirectiveArgs(container, inventorySlot), player, user);
+                    const actionDirective = this.#createActionDirective(StashAction, entity.getStashActionDirectiveArgs(container, inventorySlot), player, user);
                     const containerName = container.inventory.size > 1 ? `${inventorySlot.id} of ${container.name}` : container.name;
                     const stringSelectLabel = `${entity.name} ${container.getPreposition()} ${containerName}`;
                     const buttonLabel = `Stash ${stringSelectLabel}`;
@@ -409,7 +408,7 @@ export default class ClientInteractableManager {
             }
         }
         if (viableContainers.values().reduce((sum, inventorySlots) => sum + inventorySlots.length, 0) > 2) {
-            const actionDirective = await this.#createActionDirective(StashAction, ["StashAction Menu"], player, user);
+            const actionDirective = this.#createActionDirective(StashAction, ["StashAction Menu"], player, user);
             return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Stash", ActionPriority.STASH);
         }
         else return this.#createButtonInteractables(interactableOptions, ButtonStyle.Primary, ActionPriority.STASH);
@@ -421,11 +420,11 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createUnstashActionInteractables(entities: InventoryItem[], player: Player, user: User = player): Promise<(ButtonInteractable | StringSelectMenuInteractable)[]> {
+    createUnstashActionInteractables(entities: InventoryItem[], player: Player, user: User = player): ButtonOrStringSelectMenuInteractable[] {
         if (!player.canUseCommand("unstash")) return [];
         const interactableOptions: InteractableOptions<UnstashAction>[] = [];
         for (const entity of entities) {
-            const actionDirective = await this.#createActionDirective(UnstashAction, entity.getUnstashActionDirectiveArgs(), player, user);
+            const actionDirective = this.#createActionDirective(UnstashAction, entity.getUnstashActionDirectiveArgs(), player, user);
             const stringSelectLabel = `${entity.name}`;
             const buttonLabel = `Unstash ${stringSelectLabel}`;
             const containerString = entity.container !== null && entity.container.inventory.size > 1 ?
@@ -436,7 +435,7 @@ export default class ClientInteractableManager {
         }
         const uniqueEntityNames = new Set(entities.map(entity => entity.name));
         if (entities.length > 4 || uniqueEntityNames.size !== entities.length) {
-            const actionDirective = await this.#createActionDirective(UnstashAction, ["UnstashAction Menu"], player, user);
+            const actionDirective = this.#createActionDirective(UnstashAction, ["UnstashAction Menu"], player, user);
             return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Unstash", ActionPriority.UNSTASH);
         }
         else return this.#createButtonInteractables(interactableOptions, ButtonStyle.Primary, ActionPriority.UNSTASH);
@@ -448,14 +447,14 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createEquipActionInteractables(equippableItems: Map<InventoryItem, string[]>, player: Player, user: User = player): Promise<(ButtonInteractable | StringSelectMenuInteractable)[]> {
+    createEquipActionInteractables(equippableItems: Map<InventoryItem, string[]>, player: Player, user: User = player): ButtonOrStringSelectMenuInteractable[] {
         if (!player.canUseCommand("equip")) return [];
         const interactableOptions: InteractableOptions<EquipAction>[] = [];
         for (const [heldItem, equipmentSlots] of equippableItems.entries()) {
             for (const equipmentSlotId of equipmentSlots) {
                 const equipmentSlot = player.inventory.get(equipmentSlotId);
                 if (!equipmentSlot || equipmentSlot.equippedItem !== null) continue;
-                const actionDirective = await this.#createActionDirective(EquipAction, heldItem.getEquipActionDirectiveArgs(equipmentSlot), player, user);
+                const actionDirective = this.#createActionDirective(EquipAction, heldItem.getEquipActionDirectiveArgs(equipmentSlot), player, user);
                 const stringSelectLabel = `${heldItem.name} to ${equipmentSlot.id}`;
                 const buttonLabel = `Equip ${heldItem.name}`;
                 const description = `Equip ${heldItem.name} to ${equipmentSlot.id}`;
@@ -463,7 +462,7 @@ export default class ClientInteractableManager {
             }
         }
         if (equippableItems.values().reduce((sum, equipmentSlots) => sum + equipmentSlots.length, 0) > 1) {
-            const actionDirective = await this.#createActionDirective(EquipAction, ["EquipAction Menu"], player, user);
+            const actionDirective = this.#createActionDirective(EquipAction, ["EquipAction Menu"], player, user);
             return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Equip", ActionPriority.EQUIP);
         }
         else return this.#createButtonInteractables(interactableOptions, ButtonStyle.Secondary, ActionPriority.EQUIP);
@@ -475,14 +474,14 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createUnequipActionInteractables(unequippableItems: InventoryItem[], player: Player, user: User = player): Promise<StringSelectMenuInteractable[]> {
+    createUnequipActionInteractables(unequippableItems: InventoryItem[], player: Player, user: User = player): StringSelectMenuInteractable[] {
         if (!player.canUseCommand("unequip")) return [];
         const interactableOptions: InteractableOptions<UnequipAction>[] = [];
         for (const item of unequippableItems) {
-            const actionDirective = await this.#createActionDirective(UnequipAction, item.getUnequipActionDirectiveArgs(), player, user);
+            const actionDirective = this.#createActionDirective(UnequipAction, item.getUnequipActionDirectiveArgs(), player, user);
             interactableOptions.push(new InteractableOptions(actionDirective, `Unequip ${item.name}`, `${item.name}`, `Unequip ${item.name} from ${item.equipmentSlot}`));
         }
-        const actionDirective = await this.#createActionDirective(UnequipAction, ["UnequipAction Menu"], player, user);
+        const actionDirective = this.#createActionDirective(UnequipAction, ["UnequipAction Menu"], player, user);
         return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Unequip", ActionPriority.UNEQUIP);
     }
 
@@ -492,10 +491,10 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createCraftActionInteractables(recipe: Recipe, player: Player, user: User = player): Promise<ButtonInteractable[]> {
+    createCraftActionInteractables(recipe: Recipe, player: Player, user: User = player): ButtonInteractable[] {
         if (!player.canUseCommand("craft")) return [];
         const heldItems = getSortedItems(this.#game.entityFinder.getPlayerHands(player).filter(hand => hand.equippedItem !== null).map(hand => hand.equippedItem));
-        const actionDirective = await this.#createActionDirective(CraftAction, player.getCraftActionDirectiveArgs(heldItems[0], heldItems[1], recipe), player, user);
+        const actionDirective = this.#createActionDirective(CraftAction, player.getCraftActionDirectiveArgs(heldItems[0], heldItems[1], recipe), player, user);
         const interactableOptions = new InteractableOptions(actionDirective, `Craft ${heldItems[0].name} and ${heldItems[1].name}`);
         return [this.#createButtonInteractable(interactableOptions, ButtonStyle.Success, ActionPriority.CRAFT)];
     }
@@ -506,10 +505,10 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createUncraftActionInteractables(recipe: Recipe, player: Player, user: User = player): Promise<ButtonInteractable[]> {
+    createUncraftActionInteractables(recipe: Recipe, player: Player, user: User = player): ButtonInteractable[] {
         if (!player.canUseCommand("uncraft")) return [];
         const heldItems = getSortedItems(this.#game.entityFinder.getPlayerHands(player).filter(hand => hand.equippedItem !== null).map(hand => hand.equippedItem));
-        const actionDirective = await this.#createActionDirective(UncraftAction, player.getUncraftActionDirectiveArgs(heldItems[0], recipe), player, user);
+        const actionDirective = this.#createActionDirective(UncraftAction, player.getUncraftActionDirectiveArgs(heldItems[0], recipe), player, user);
         const interactableOptions = new InteractableOptions(actionDirective, `Uncraft ${heldItems[0].name}`);
         return [this.#createButtonInteractable(interactableOptions, ButtonStyle.Secondary, ActionPriority.UNCRAFT)];
     }
@@ -520,17 +519,17 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createUseActionInteractables(usableItems: InventoryItem[], player: Player, user: User = player): Promise<StringSelectMenuInteractable[]> {
+    createUseActionInteractables(usableItems: InventoryItem[], player: Player, user: User = player): StringSelectMenuInteractable[] {
         if (!player.canUseCommand("use")) return [];
         const interactableOptions: InteractableOptions<UseAction>[] = [];
         for (const item of usableItems) {
-            const actionDirective = await this.#createActionDirective(UseAction, item.getUseActionDirectiveArgs(player), player, user);
+            const actionDirective = this.#createActionDirective(UseAction, item.getUseActionDirectiveArgs(player), player, user);
             const verb = item.prefab.secondPersonVerb ? capitalizeFirstLetter(item.prefab.secondPersonVerb) : "Use";
             const stringSelectLabel = `${item.name}`;
             const description = `${verb} ${stringSelectLabel}`;
             interactableOptions.push(new InteractableOptions(actionDirective, description, stringSelectLabel, description));
         }
-        const actionDirective = await this.#createActionDirective(UseAction, ["UseAction Menu"], player, user);
+        const actionDirective = this.#createActionDirective(UseAction, ["UseAction Menu"], player, user);
         return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Use", ActionPriority.USE);
     }
 
@@ -540,9 +539,9 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createActivateInteractables(fixture: Fixture, player: Player, user: User = player): Promise<ButtonInteractable[]> {
+    createActivateInteractables(fixture: Fixture, player: Player, user: User = player): ButtonInteractable[] {
         if (!player.canUseCommand("use")) return [];
-        const actionDirective = await this.#createActionDirective(ActivateAction, fixture.getActivateOrDeactivateActionDirectiveArgs(true), player, user);
+        const actionDirective = this.#createActionDirective(ActivateAction, fixture.getActivateOrDeactivateActionDirectiveArgs(true), player, user);
         const interactableOptions = new InteractableOptions(actionDirective, `Activate ${fixture.name}`);
         return [this.#createButtonInteractable(interactableOptions, ButtonStyle.Secondary, ActionPriority.ACTIVATE)];
     }
@@ -553,9 +552,9 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async createDeactivateInteractables(fixture: Fixture, player: Player, user: User = player): Promise<ButtonInteractable[]> {
+    createDeactivateInteractables(fixture: Fixture, player: Player, user: User = player): ButtonInteractable[] {
         if (!player.canUseCommand("use")) return [];
-        const actionDirective = await this.#createActionDirective(DeactivateAction, fixture.getActivateOrDeactivateActionDirectiveArgs(true), player, user);
+        const actionDirective = this.#createActionDirective(DeactivateAction, fixture.getActivateOrDeactivateActionDirectiveArgs(true), player, user);
         const interactableOptions = new InteractableOptions(actionDirective, `Deactivate ${fixture.name}`);
         return [this.#createButtonInteractable(interactableOptions, ButtonStyle.Secondary, ActionPriority.DEACTIVATE)];
     }
@@ -567,11 +566,11 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for.
      */
-    async createInstantiateInventoryItemActionInteractables(freeEquipmentSlots: EquipmentSlot[], viableContainers: Map<InventoryItem, string[]>, player: Player, user: User): Promise<(ButtonInteractable | StringSelectMenuInteractable)[]> {
+    createInstantiateInventoryItemActionInteractables(freeEquipmentSlots: EquipmentSlot[], viableContainers: Map<InventoryItem, string[]>, player: Player, user: User): ButtonOrStringSelectMenuInteractable[] {
         const interactableOptions: InteractableOptions<InstantiateInventoryItemAction>[] = [];
         for (const equipmentSlot of freeEquipmentSlots) {
             if (equipmentSlot.equippedItem !== null) continue;
-            const actionDirective = await this.#createActionDirective(InstantiateInventoryItemAction, equipmentSlot.getPartialInstantiateActionDirectiveArgs(), player, user);
+            const actionDirective = this.#createActionDirective(InstantiateInventoryItemAction, equipmentSlot.getPartialInstantiateActionDirectiveArgs(), player, user);
             const stringSelectLabel = `${equipmentSlot.id}`;
             const buttonLabel = `Instantiate to ${stringSelectLabel}`;
             const description = `Instantiate to ${equipmentSlot.id}`;
@@ -581,7 +580,7 @@ export default class ClientInteractableManager {
             for (const inventorySlotId of inventorySlots) {
                 const inventorySlot = container.inventory.get(inventorySlotId);
                 if (!inventorySlot || inventorySlot.takenSpace >= inventorySlot.capacity) continue;
-                const actionDirective = await this.#createActionDirective(InstantiateInventoryItemAction, container.getPartialInstantiateActionDirectiveArgs(inventorySlot), player ?? container.player, user);
+                const actionDirective = this.#createActionDirective(InstantiateInventoryItemAction, container.getPartialInstantiateActionDirectiveArgs(inventorySlot), player ?? container.player, user);
                 const containerName = container.inventory.size > 1 ? `${inventorySlot.id} of ${container.getIdentifier()}` : container.getIdentifier();
                 const stringSelectLabel = `${containerName}`;
                 const buttonLabel = `Instantiate ${container.getPreposition()} ${stringSelectLabel}`;
@@ -591,7 +590,7 @@ export default class ClientInteractableManager {
         }
         const uniqueButtonLabels = new Set(interactableOptions.map(option => `${option.buttonLabel}`));
         if (interactableOptions.length > 2 || uniqueButtonLabels.size !== interactableOptions.length) {
-            const actionDirective = await this.#createActionDirective(InstantiateInventoryItemAction, ["InstantiateInventoryItemAction Menu"], player, user);
+            const actionDirective = this.#createActionDirective(InstantiateInventoryItemAction, ["InstantiateInventoryItemAction Menu"], player, user);
             return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Instantiate", ActionPriority.INSTANTIATE);
         }
         else return this.#createButtonInteractables(interactableOptions, ButtonStyle.Success, ActionPriority.INSTANTIATE);
@@ -604,7 +603,7 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for.
      */
-    async createInstantiateInventoryItemActionModalInteractable(args: [string, string, string, string], player: Player, user: User): Promise<ModalInteractable> {
+    createInstantiateInventoryItemActionModalInteractable(args: [string, string, string, string], player: Player, user: User): ModalInteractable {
         const equipmentSlotId = args[1];
         const containerIdentifier = args[2];
         const inventorySlotId = args[3];
@@ -614,7 +613,7 @@ export default class ClientInteractableManager {
             inputs.push(new TextInputInteractable("Instantiate Inventory Item Quantity", "Quantity", "Number.", true, "1"));
         inputs.push(new TextInputInteractable("Instantiate Inventory Item Uses", "Uses", "Number. If not provided, item will be instantiated with its default uses.", false));
         inputs.push(new TextInputInteractable("Instantiate Inventory Item Procedural Selections", "Procedural Selections", "Example: (color=metal + character=upa)", false, undefined, undefined, 5));
-        const modalActionDirective = await this.#createActionDirective(InstantiateInventoryItemAction, args.concat(["Modal"]), player, user);
+        const modalActionDirective = this.#createActionDirective(InstantiateInventoryItemAction, args.concat(["Modal"]), player, user);
         const description = containerIdentifier ? `Instantiate to ${inventorySlotId} of ${player.name}'s ${containerIdentifier}` : `Instantiate to ${player.name}'s ${equipmentSlotId}`;
         const modal = new ModalInteractable(modalActionDirective, "Instantiate Inventory Item", inputs, ActionPriority.INSTANTIATE, description);
         this.addInteractable(modal);
@@ -626,14 +625,14 @@ export default class ClientInteractableManager {
      * @param viableContainers - A map of viable room item containers and (optionally) inventory slots an item can be instantiated into.
      * @param user - The user these interactables are being created for.
      */
-    async createInstantiateRoomItemActionInteractables(viableContainers: Map<RoomItemContainer, string[]>, user: User): Promise<(ButtonInteractable | StringSelectMenuInteractable)[]> {
+    createInstantiateRoomItemActionInteractables(viableContainers: Map<RoomItemContainer, string[]>, user: User): ButtonOrStringSelectMenuInteractable[] {
         const interactableOptions: InteractableOptions<InstantiateRoomItemAction>[] = [];
         for (const [container, inventorySlots] of viableContainers.entries()) {
             if (container instanceof RoomItem) {
                 for (const inventorySlotId of inventorySlots) {
                     const inventorySlot = container.inventory.get(inventorySlotId);
                     if (!inventorySlot || inventorySlot.takenSpace >= inventorySlot.capacity) continue;
-                    const actionDirective = await this.#createActionDirective(InstantiateRoomItemAction, container.getPartialInstantiateActionDirectiveArgs(inventorySlot), undefined, user);
+                    const actionDirective = this.#createActionDirective(InstantiateRoomItemAction, container.getPartialInstantiateActionDirectiveArgs(inventorySlot), undefined, user);
                     const containerName = container.inventory.size > 1 ? `${inventorySlot.id} of ${container.getIdentifier()}` : container.getIdentifier();
                     const stringSelectLabel = `${containerName}`;
                     const buttonLabel = `Instantiate ${container.getPreposition()} ${stringSelectLabel}`;
@@ -643,7 +642,7 @@ export default class ClientInteractableManager {
             }
             else {
                 if (!container.canCurrentlyContainItems(true, true)) continue;
-                const actionDirective = await this.#createActionDirective(InstantiateRoomItemAction, container.getPartialInstantiateActionDirectiveArgs(), undefined, user);
+                const actionDirective = this.#createActionDirective(InstantiateRoomItemAction, container.getPartialInstantiateActionDirectiveArgs(), undefined, user);
                 const containerName = container.getContainerIdentifier();
                 const stringSelectLabel = `${containerName}`;
                 const buttonLabel = `Instantiate ${container.getPreposition()} ${stringSelectLabel}`;
@@ -653,7 +652,7 @@ export default class ClientInteractableManager {
         }
         const uniqueButtonLabels = new Set(interactableOptions.map(option => `${option.buttonLabel}`));
         if (interactableOptions.length > 2 || uniqueButtonLabels.size !== interactableOptions.length) {
-            const actionDirective = await this.#createActionDirective(InstantiateRoomItemAction, ["InstantiateRoomItemAction Menu"], undefined, user);
+            const actionDirective = this.#createActionDirective(InstantiateRoomItemAction, ["InstantiateRoomItemAction Menu"], undefined, user);
             return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Instantiate", ActionPriority.INSTANTIATE);
         }
         else return this.#createButtonInteractables(interactableOptions, ButtonStyle.Success, ActionPriority.INSTANTIATE);
@@ -665,7 +664,7 @@ export default class ClientInteractableManager {
      * @param args - An array of partial instantiate room item action directive args. ["??", identifier, location, preposition, .?, .?, destinationInventorySlot]
      * @param user - The user these interactables are being created for.
      */
-    async createInstantiateRoomItemActionModalInteractable(args: string[], user: User): Promise<ModalInteractable> {
+    createInstantiateRoomItemActionModalInteractable(args: string[], user: User): ModalInteractable {
         const containerIdentifier = args[1];
         const locationDisplayName = args[2];
         const preposition = args[3];
@@ -676,7 +675,7 @@ export default class ClientInteractableManager {
         inputs.push(new TextInputInteractable("Instantiate Room Item Quantity", "Quantity", "Number.", true, "1"));
         inputs.push(new TextInputInteractable("Instantiate Room Item Uses", "Uses", "Number. If not provided, item will be instantiated with its default uses.", false));
         inputs.push(new TextInputInteractable("Instantiate Room Item Procedural Selections", "Procedural Selections", "Example: (color=metal + character=upa)", false, undefined, undefined, 5));
-        const modalActionDirective = await this.#createActionDirective(InstantiateRoomItemAction, args.concat(["Modal"]), undefined, user);
+        const modalActionDirective = this.#createActionDirective(InstantiateRoomItemAction, args.concat(["Modal"]), undefined, user);
         const description = `Instantiate ${preposition} ${containerPhrase} at ${locationDisplayName}`;
         const modal = new ModalInteractable(modalActionDirective, "Instantiate Room Item", inputs, ActionPriority.INSTANTIATE, description);
         this.addInteractable(modal);
@@ -689,10 +688,10 @@ export default class ClientInteractableManager {
      * @param player - The player these interactables are being created for.
      * @param user - The user these interactables are being created for.
      */
-    async createDestroyInventoryItemActionInteractables(destroyableItems: InventoryItem[], player: Player, user: User): Promise<(ButtonInteractable | StringSelectMenuInteractable)[]> {
+    createDestroyInventoryItemActionInteractables(destroyableItems: InventoryItem[], player: Player, user: User): ButtonOrStringSelectMenuInteractable[] {
         const interactableOptions: InteractableOptions<DestroyInventoryItemAction>[] = [];
         for (const item of destroyableItems) {
-            const actionDirective = await this.#createActionDirective(DestroyInventoryItemAction, item.getDestroyActionDirectiveArgs(), player ?? item.player, user);
+            const actionDirective = this.#createActionDirective(DestroyInventoryItemAction, item.getDestroyActionDirectiveArgs(), player ?? item.player, user);
             let containerString: string;
             if (item.container !== null) {
                 containerString = `${item.container.getPreposition()} `;
@@ -707,7 +706,7 @@ export default class ClientInteractableManager {
         }
         const uniqueButtonLabels = new Set(interactableOptions.map(option => option.buttonLabel));
         if (interactableOptions.length > 2 || uniqueButtonLabels.size !== interactableOptions.length) {
-            const actionDirective = await this.#createActionDirective(DestroyInventoryItemAction, ["DestroyInventoryItemAction Menu"], player, user);
+            const actionDirective = this.#createActionDirective(DestroyInventoryItemAction, ["DestroyInventoryItemAction Menu"], player, user);
             return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Destroy", ActionPriority.DESTROY);
         }
         else return this.#createButtonInteractables(interactableOptions, ButtonStyle.Danger, ActionPriority.DESTROY);
@@ -718,11 +717,11 @@ export default class ClientInteractableManager {
      * @param itemContainers - A list of item containers to create Interactables for.
      * @param user - The user these interactables are being created for.
      */
-    async createDestroyRoomItemActionInteractables(itemContainers: RoomItemContainer[], user: User): Promise<(ButtonInteractable | StringSelectMenuInteractable)[]> {
+    createDestroyRoomItemActionInteractables(itemContainers: RoomItemContainer[], user: User): ButtonOrStringSelectMenuInteractable[] {
         const interactableOptions: InteractableOptions<DestroyRoomItemAction>[] = [];
         for (const container of itemContainers) {
             if (container instanceof RoomItem) {
-                const actionDirective = await this.#createActionDirective(DestroyRoomItemAction, container.getDestroyRoomItemActionDirectiveArgs(), undefined, user);
+                const actionDirective = this.#createActionDirective(DestroyRoomItemAction, container.getDestroyRoomItemActionDirectiveArgs(), undefined, user);
                 let containerString = `${container.container.getPreposition()} `;
                 if (container.container instanceof RoomItem) {
                     if (container.container.inventory.size > 1) containerString += `${container.slot} of `;
@@ -736,7 +735,7 @@ export default class ClientInteractableManager {
                 interactableOptions.push(new InteractableOptions(actionDirective, buttonLabel, stringSelectLabel, description));
             }
             if (container.isItemContainer() && container.canCurrentlyContainItems(false, true) && !container.containsNoItems()) {
-                const actionDirective = await this.#createActionDirective(DestroyRoomItemAction, container.getDestroyAllRoomItemActionDirectiveArgs(), undefined, user);
+                const actionDirective = this.#createActionDirective(DestroyRoomItemAction, container.getDestroyAllRoomItemActionDirectiveArgs(), undefined, user);
                 const containerString = `${container.getPreposition()} ${container.getContainerIdentifier()}`;
                 const stringSelectLabel = `All ${containerString}`;
                 const buttonLabel = `Destroy all ${containerString}`;
@@ -746,7 +745,7 @@ export default class ClientInteractableManager {
         }
         const uniqueButtonLabels = new Set(interactableOptions.map(option => option.buttonLabel));
         if (interactableOptions.length > 2 || uniqueButtonLabels.size !== interactableOptions.length) {
-            const actionDirective = await this.#createActionDirective(DestroyRoomItemAction, ["DestroyRoomItemAction Menu"], undefined, user);
+            const actionDirective = this.#createActionDirective(DestroyRoomItemAction, ["DestroyRoomItemAction Menu"], undefined, user);
             return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Destroy", ActionPriority.DESTROY);
         }
         else return this.#createButtonInteractables(interactableOptions, ButtonStyle.Danger, ActionPriority.DESTROY);
@@ -757,15 +756,15 @@ export default class ClientInteractableManager {
      * @param argsSets - Sets of args to be passed into performFind as search queries.
      * @param user - The user these interactables are being created for.
      */
-    async createFindActionInteractables(argsSets: [string][], user: User): Promise<StringSelectMenuInteractable[]> {
+    createFindActionInteractables(argsSets: [string][], user: User): StringSelectMenuInteractable[] {
         const interactableOptions: InteractableOptions<FindAction>[] = [];
         for (const args of argsSets) {
-            const actionDirective = await this.#createActionDirective(FindAction, args, undefined, user);
+            const actionDirective = this.#createActionDirective(FindAction, args, undefined, user);
             const stringSelectLabel = `${args[0]}`;
             const buttonLabel = `Find ${stringSelectLabel}`;
             interactableOptions.push(new InteractableOptions(actionDirective, buttonLabel, stringSelectLabel, buttonLabel));
         }
-        const actionDirective = await this.#createActionDirective(FindAction, ["FindAction Menu"], undefined, user);
+        const actionDirective = this.#createActionDirective(FindAction, ["FindAction Menu"], undefined, user);
         return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Find", ActionPriority.FIND);
     }
 
@@ -774,7 +773,7 @@ export default class ClientInteractableManager {
      * @param container - The container to search in.
      * @param user - The user these interactables are being created for.
      */
-    async createFindContainedItemsActionInteractables(container: RoomItemContainer | InventoryItem, user: User): Promise<(ButtonInteractable | StringSelectMenuInteractable)[]> {
+    createFindContainedItemsActionInteractables(container: RoomItemContainer | InventoryItem, user: User): ButtonOrStringSelectMenuInteractable[] {
         const interactableOptions: InteractableOptions<FindAction>[] = [];
         let inventorySlotIDs: string[] = [undefined];
         if ((container instanceof RoomItem || container instanceof InventoryItem) && container.inventory.size > 1) {
@@ -783,7 +782,7 @@ export default class ClientInteractableManager {
             }
         }
         for (const inventorySlotID of inventorySlotIDs) {
-            const actionDirective = await this.#createActionDirective(FindAction, container.getFindChildItemsActionDirectiveArgs(inventorySlotID), undefined, user);
+            const actionDirective = this.#createActionDirective(FindAction, container.getFindChildItemsActionDirectiveArgs(inventorySlotID), undefined, user);
             let containerString = `${container.getPreposition()} `;
             const slotPhrase = inventorySlotID ? `${inventorySlotID} of ` : ``;
             const stringSelectLabel = `${slotPhrase}${container.getContainerIdentifier()}`;
@@ -793,7 +792,7 @@ export default class ClientInteractableManager {
             interactableOptions.push(new InteractableOptions(actionDirective, buttonLabel, stringSelectLabel, description));
         }
         if (interactableOptions.length > 1) {
-            const actionDirective = await this.#createActionDirective(FindAction, ["FindContainedItemsAction Menu"], undefined, user);
+            const actionDirective = this.#createActionDirective(FindAction, ["FindContainedItemsAction Menu"], undefined, user);
             return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "Find Contained Items", ActionPriority.FIND);
         }
         else return this.#createButtonInteractables(interactableOptions, ButtonStyle.Secondary, ActionPriority.FIND);
@@ -806,16 +805,16 @@ export default class ClientInteractableManager {
      * @param user - The user these interactables are being created for.
      * @returns An array of button interactables, if the number of fields is less than or equal to 5. Otherwise, returns an array containing one string select menu interactable.
      */
-    async createViewFieldActionInteractables<T extends PersistentGameEntity>(entity: T, fields: EntityField<T>[], user: User): Promise<(ButtonInteractable | StringSelectMenuInteractable)[]> {
+    createViewFieldActionInteractables<T extends PersistentGameEntity>(entity: T, fields: EntityField<T>[], user: User): ButtonOrStringSelectMenuInteractable[] {
         const interactableOptions: InteractableOptions<ViewAction>[] = [];
         for (const field of fields) {
-            const actionDirective = await this.#createActionDirective(ViewAction, [entity.getEntityType(), entity.row, field], undefined, user);
+            const actionDirective = this.#createActionDirective(ViewAction, [entity.getEntityType(), entity.row, field], undefined, user);
             const stringSelectLabel = entity.getLabel(field);
             const buttonLabel = `View ${stringSelectLabel}`;
             interactableOptions.push(new InteractableOptions(actionDirective, buttonLabel, stringSelectLabel, buttonLabel));
         }
         if (fields.length > 5) {
-            const actionDirective = await this.#createActionDirective(ViewAction, ["ViewFieldAction Menu"], undefined, user);
+            const actionDirective = this.#createActionDirective(ViewAction, ["ViewFieldAction Menu"], undefined, user);
             return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, `View Field of ${entity.getEntityID()}`, ActionPriority.VIEW_FIELD);
         }
         else return this.#createButtonInteractables(interactableOptions, ButtonStyle.Primary, ActionPriority.VIEW_FIELD);
@@ -826,10 +825,10 @@ export default class ClientInteractableManager {
      * @param entities - A list of entities to view.
      * @param user - The user these interactables are being created for.
      */
-    async createViewActionInteractables(entities: PersistentGameEntity[], user: User): Promise<StringSelectMenuInteractable[]> {
+    createViewActionInteractables(entities: PersistentGameEntity[], user: User): StringSelectMenuInteractable[] {
         const interactableOptions: InteractableOptions<ViewAction>[] = [];
         for (const entity of entities) {
-            const actionDirective = await this.#createActionDirective(ViewAction, [entity.getEntityType(), entity.row], undefined, user);
+            const actionDirective = this.#createActionDirective(ViewAction, [entity.getEntityType(), entity.row], undefined, user);
             const stringSelectLabel = `${entity.getEntityID()}`;
             const buttonLabel = `View ${stringSelectLabel}`;
             let description: string;
@@ -837,7 +836,7 @@ export default class ClientInteractableManager {
             else description = `View ${entity.getEntityType()} ${entity.getEntityID()} on row ${entity.row}`;
             interactableOptions.push(new InteractableOptions(actionDirective, buttonLabel, stringSelectLabel, description));
         }
-        const actionDirective = await this.#createActionDirective(ViewAction, ["ViewAction Menu"], undefined, user);
+        const actionDirective = this.#createActionDirective(ViewAction, ["ViewAction Menu"], undefined, user);
         return this.#createStringSelectMenuInteractable(actionDirective, interactableOptions, "View Entity", ActionPriority.VIEW);
     }
 
@@ -848,13 +847,13 @@ export default class ClientInteractableManager {
      * @param player - The player who can perform a take action.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async getTakeInteractables(container: RoomItemContainer, containedItems: RoomItem[], player: Player, user: User = player): Promise<Interactable[]> {
+    getTakeInteractables(container: RoomItemContainer, containedItems: RoomItem[], player: Player, user: User = player): Interactable[] {
         let interactables: Interactable[] = [];
         const playerFreeHand = this.#game.entityFinder.getPlayerFreeHand(player);
         let dropContainer = container;
         if (dropContainer instanceof Fixture && dropContainer.childPuzzle !== null && dropContainer.childPuzzle.isItemContainer()) dropContainer = container;
         if (playerFreeHand && dropContainer.canCurrentlyContainItems(false, user instanceof Moderator))
-            interactables = interactables.concat(await this.createTakeActionInteractable(containedItems, player, user));
+            interactables = interactables.concat(this.createTakeActionInteractable(containedItems, player, user));
         return interactables;
     }
 
@@ -864,7 +863,7 @@ export default class ClientInteractableManager {
      * @param player - The player who can perform a drop action.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async getDropInteractables(container: RoomItemContainer, player: Player, user: User = player): Promise<Interactable[]> {
+    getDropInteractables(container: RoomItemContainer, player: Player, user: User = player): Interactable[] {
         let interactables: Interactable[] = [];
         let dropContainer = container;
         if (dropContainer instanceof Fixture && dropContainer.childPuzzle !== null && dropContainer.childPuzzle.isItemContainer())
@@ -872,7 +871,7 @@ export default class ClientInteractableManager {
         if (dropContainer.canCurrentlyContainItems(true, user instanceof Moderator)) {
             if (dropContainer.isItemContainer()) {
                 const droppableEntities = this.#game.entityFinder.getPlayerHands(player).filter(equipmentSlot => equipmentSlot.equippedItem !== null).map(equipmentSlot => equipmentSlot.equippedItem);
-                if (droppableEntities.length !== 0) interactables = interactables.concat(await this.createDropActionInteractables(droppableEntities, player, dropContainer, user));
+                if (droppableEntities.length !== 0) interactables = interactables.concat(this.createDropActionInteractables(droppableEntities, player, dropContainer, user));
             }
         }
         return interactables;
@@ -883,7 +882,7 @@ export default class ClientInteractableManager {
      * @param player - The player who can perform a stash action.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async getStashInteractables(player: Player, user: User = player): Promise<Interactable[]> {
+    getStashInteractables(player: Player, user: User = player): Interactable[] {
         let interactables: Interactable[] = [];
         const playerItems = this.#game.entityFinder.getInventoryItems(undefined, player.name);
         const heldItems = this.#game.entityFinder.getPlayerHands(player).filter(hand => hand.equippedItem !== null).map(hand => hand.equippedItem);
@@ -912,7 +911,7 @@ export default class ClientInteractableManager {
                     if (viableInventorySlots.length > 0) viableStashDestinations.set(containerItem, viableInventorySlots);
                 }
             }
-            interactables = interactables.concat(await this.createStashActionInteractables(heldItems, player, viableStashDestinations, user));
+            interactables = interactables.concat(this.createStashActionInteractables(heldItems, player, viableStashDestinations, user));
         }
         return interactables;
     }
@@ -922,7 +921,7 @@ export default class ClientInteractableManager {
      * @param player - The player who can perform an unstash action.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async getUnstashInteractables(player: Player, user: User = player): Promise<Interactable[]> {
+    getUnstashInteractables(player: Player, user: User = player): Interactable[] {
         let interactables: Interactable[] = [];
         const playerItems = this.#game.entityFinder.getInventoryItems(undefined, player.name);
         const playerFreeHand = this.#game.entityFinder.getPlayerFreeHand(player);
@@ -930,7 +929,7 @@ export default class ClientInteractableManager {
         if (playerFreeHand && playerContainerItems.length > 0) {
             const stashedItems = playerItems.filter(item => item.container !== null);
             if (stashedItems.length > 0) {
-                interactables = interactables.concat(await this.createUnstashActionInteractables(stashedItems, player, user));
+                interactables = interactables.concat(this.createUnstashActionInteractables(stashedItems, player, user));
             }
         }
         return interactables;
@@ -941,7 +940,7 @@ export default class ClientInteractableManager {
      * @param player - The player who can perform an equip action.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async getEquipInteractables(player: Player, user: User = player): Promise<Interactable[]> {
+    getEquipInteractables(player: Player, user: User = player): Interactable[] {
         let interactables: Interactable[] = [];
         const hands = this.#game.entityFinder.getPlayerHands(player);
         const heldItems = hands.filter(hand => hand.equippedItem !== null).map(hand => hand.equippedItem);
@@ -959,7 +958,7 @@ export default class ClientInteractableManager {
                 }
                 if (viableEquipmentSlots.length > 0) equippableItems.set(heldItem, viableEquipmentSlots);
             }
-            interactables = interactables.concat(await this.createEquipActionInteractables(equippableItems, player, user));
+            interactables = interactables.concat(this.createEquipActionInteractables(equippableItems, player, user));
         }
         return interactables;
     }
@@ -969,14 +968,14 @@ export default class ClientInteractableManager {
      * @param player - The player who can perform an unequip action.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async getUnequipInteractables(player: Player, user: User = player): Promise<Interactable[]> {
+    getUnequipInteractables(player: Player, user: User = player): Interactable[] {
         let interactables: Interactable[] = [];
         const playerFreeHand = this.#game.entityFinder.getPlayerFreeHand(player);
         const handSlotIDs = this.#game.entityFinder.getPlayerHands(player).map(hand => hand.id);
         let unequippableItems = player.inventory.filter(equipmentSlot => !handSlotIDs.includes(equipmentSlot.id) && equipmentSlot.equippedItem !== null).map(equipmentSlot => equipmentSlot.equippedItem!);
         unequippableItems = unequippableItems.filter(item => item.prefab.equippable);
         if (playerFreeHand && unequippableItems.length > 0) {
-            interactables = interactables.concat(await this.createUnequipActionInteractables(unequippableItems, player, user));
+            interactables = interactables.concat(this.createUnequipActionInteractables(unequippableItems, player, user));
         }
         return interactables;
     }
@@ -986,7 +985,7 @@ export default class ClientInteractableManager {
      * @param player - The player who can perform a craft action.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async getCraftInteractables(player: Player, user: User = player): Promise<Interactable[]> {
+    getCraftInteractables(player: Player, user: User = player): Interactable[] {
         let interactables: Interactable[] = [];
         const heldItems = this.#game.entityFinder.getPlayerHands(player).filter(hand => hand.equippedItem !== null).map(hand => hand.equippedItem);
         if (heldItems.length >= 2) {
@@ -995,7 +994,7 @@ export default class ClientInteractableManager {
             if (recipes.length === 0) return [];
             for (const recipe of recipes) {
                 if (player.canCraft(recipe, [items[0], items[1]])) {
-                    interactables = interactables.concat(await this.createCraftActionInteractables(recipe, player, user));
+                    interactables = interactables.concat(this.createCraftActionInteractables(recipe, player, user));
                     break;
                 }
             }
@@ -1008,7 +1007,7 @@ export default class ClientInteractableManager {
      * @param player - The player who can perform an uncraft action.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async getUncraftInteractables(player: Player, user: User = player): Promise<Interactable[]> {
+    getUncraftInteractables(player: Player, user: User = player): Interactable[] {
         let interactables: Interactable[] = [];
         const heldItems = this.#game.entityFinder.getPlayerHands(player).filter(hand => hand.equippedItem !== null).map(hand => hand.equippedItem);
         const playerFreeHand = this.#game.entityFinder.getPlayerFreeHand(player);
@@ -1016,7 +1015,7 @@ export default class ClientInteractableManager {
             const item = heldItems[0];
             const recipe = this.#game.entityFinder.getRecipes("uncraftable", undefined, undefined, item.prefab.id)[0];
             if (recipe)
-                interactables = interactables.concat(await this.createUncraftActionInteractables(recipe, player, user));
+                interactables = interactables.concat(this.createUncraftActionInteractables(recipe, player, user));
         }
         return interactables;
     }
@@ -1026,12 +1025,12 @@ export default class ClientInteractableManager {
      * @param player - The player who can perform a use action.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async getUseInteractables(player: Player, user: User = player): Promise<Interactable[]> {
+    getUseInteractables(player: Player, user: User = player): Interactable[] {
         let interactables: Interactable[] = [];
         const heldItems = this.#game.entityFinder.getPlayerHands(player).filter(hand => hand.equippedItem !== null).map(hand => hand.equippedItem);
         const usableItems = heldItems.filter(item => item.uses !== 0 && item.prefab.usable && item.usableOn(player));
         if (usableItems.length > 0) {
-            interactables = interactables.concat(await this.createUseActionInteractables(usableItems, player, user));
+            interactables = interactables.concat(this.createUseActionInteractables(usableItems, player, user));
         }
         return interactables;
     }
@@ -1043,15 +1042,15 @@ export default class ClientInteractableManager {
      * @param activated - Whether or not the fixture is activated. Defaults to the fixture's current activation state.
      * @param user - The user these interactables are being created for. Defaults to the given player.
      */
-    async getActivateOrDeactivateInteractables(fixture: Fixture, player: Player, activated = fixture.activated, user: User = player): Promise<Interactable[]> {
+    getActivateOrDeactivateInteractables(fixture: Fixture, player: Player, activated = fixture.activated, user: User = player): Interactable[] {
         let interactables: Interactable[] = [];
         // If there is a puzzle in the room with an identical name, we can't simply activate or deactivate it.
         const matchingPuzzle = this.#game.entityFinder.getPuzzle(fixture.name, fixture.location.id);
         if (fixture.recipeTag !== "" && !matchingPuzzle && (fixture.activatable || user instanceof Moderator)) {
             if (activated)
-                interactables = interactables.concat(await this.createDeactivateInteractables(fixture, player, user));
+                interactables = interactables.concat(this.createDeactivateInteractables(fixture, player, user));
             else
-                interactables = interactables.concat(await this.createActivateInteractables(fixture, player, user));
+                interactables = interactables.concat(this.createActivateInteractables(fixture, player, user));
         }
         return interactables;
     }
@@ -1063,7 +1062,7 @@ export default class ClientInteractableManager {
      * @param freeEquipmentSlots - An array of equipment slots with nothing equipped. Optional.
      * @param containerItems - An array of inventory items that can contain items. Optional.
      */
-    async getInstantiateInventoryItemInteractables(player: Player, user: User, freeEquipmentSlots?: EquipmentSlot[], containerItems?: InventoryItem[]): Promise<Interactable[]> {
+    getInstantiateInventoryItemInteractables(player: Player, user: User, freeEquipmentSlots?: EquipmentSlot[], containerItems?: InventoryItem[]): Interactable[] {
         let interactables: Interactable[] = [];
         if (freeEquipmentSlots === undefined) freeEquipmentSlots = player.inventory.filter(equipmentSlot => equipmentSlot.equippedItem === null).map(equipmentSlot => equipmentSlot);
         if (containerItems === undefined) containerItems = this.#game.entityFinder.getInventoryItems(undefined, player.name).filter(item => item.inventory.size > 0);
@@ -1077,7 +1076,7 @@ export default class ClientInteractableManager {
                 }
                 if (viableInventorySlots.length > 0) viableStashDestinations.set(containerItem, viableInventorySlots);
             }
-            interactables = interactables.concat(await this.createInstantiateInventoryItemActionInteractables(freeEquipmentSlots, viableStashDestinations, player, user));
+            interactables = interactables.concat(this.createInstantiateInventoryItemActionInteractables(freeEquipmentSlots, viableStashDestinations, player, user));
         }
         return interactables;
     }
@@ -1087,7 +1086,7 @@ export default class ClientInteractableManager {
      * @param itemContainers - An array of room item containers that can potentially be instantiated into.
      * @param user - The user these interactables are being created for.
      */
-    async getInstantiateRoomItemInteractables(itemContainers: RoomItemContainer[], user: User): Promise<Interactable[]> {
+    getInstantiateRoomItemInteractables(itemContainers: RoomItemContainer[], user: User): Interactable[] {
         let interactables: Interactable[] = [];
         if (itemContainers.length > 0) {
             const viableInstantiateDestinations = new Map<RoomItemContainer, string[]>();
@@ -1103,7 +1102,7 @@ export default class ClientInteractableManager {
                 else if (itemContainer.isItemContainer() && itemContainer.canCurrentlyContainItems(true, true))
                     viableInstantiateDestinations.set(itemContainer, []);
             }
-            interactables = interactables.concat(await this.createInstantiateRoomItemActionInteractables(viableInstantiateDestinations, user));
+            interactables = interactables.concat(this.createInstantiateRoomItemActionInteractables(viableInstantiateDestinations, user));
         }
         return interactables;
     }
@@ -1115,12 +1114,12 @@ export default class ClientInteractableManager {
      * @param equippedItems - An array of inventory items the player has equipped. Optional.
      * @param stashedItems - An array of inventory items the player has stashed. Optional.
      */
-    async getDestroyInventoryItemInteractables(player: Player, user: User, equippedItems?: InventoryItem[], stashedItems?: InventoryItem[]): Promise<Interactable[]> {
+    getDestroyInventoryItemInteractables(player: Player, user: User, equippedItems?: InventoryItem[], stashedItems?: InventoryItem[]): Interactable[] {
         let interactables: Interactable[] = [];
         if (equippedItems === undefined) equippedItems = player.inventory.filter(equipmentSlot => equipmentSlot.equippedItem !== null).map(equipmentSlot => equipmentSlot.equippedItem);
         if (stashedItems === undefined) stashedItems = this.#game.entityFinder.getInventoryItems(undefined, player.name).filter(item => item.container !== null);
         if (equippedItems.length > 0 || stashedItems.length > 0) {
-            interactables = interactables.concat(await this.createDestroyInventoryItemActionInteractables(equippedItems.concat(stashedItems), player, user));
+            interactables = interactables.concat(this.createDestroyInventoryItemActionInteractables(equippedItems.concat(stashedItems), player, user));
         }
         return interactables;
     }
@@ -1130,10 +1129,10 @@ export default class ClientInteractableManager {
      * @param itemContainers - The item containers to destroy inventory items for.
      * @param user - The user these interactables are being created for.
      */
-    async getDestroyRoomItemInteractables(itemContainers: RoomItemContainer[], user: User): Promise<Interactable[]> {
+    getDestroyRoomItemInteractables(itemContainers: RoomItemContainer[], user: User): Interactable[] {
         let interactables: Interactable[] = [];
         if (itemContainers.length > 0) {
-            interactables = interactables.concat(await this.createDestroyRoomItemActionInteractables(itemContainers, user));
+            interactables = interactables.concat(this.createDestroyRoomItemActionInteractables(itemContainers, user));
         }
         return interactables;
     }
@@ -1143,10 +1142,10 @@ export default class ClientInteractableManager {
      * @param container - The container to search in.
      * @param user - The user these interactables are being created for.
      */
-    async getFindContainedItemsInteractables(container: RoomItemContainer | InventoryItem, user: User): Promise<Interactable[]> {
+    getFindContainedItemsInteractables(container: RoomItemContainer | InventoryItem, user: User): Interactable[] {
         let interactables: Interactable[] = [];
         if (container && !container.containsNoItems())
-            interactables = interactables.concat(await this.createFindContainedItemsActionInteractables(container, user));
+            interactables = interactables.concat(this.createFindContainedItemsActionInteractables(container, user));
         return interactables;
     }
 
@@ -1157,12 +1156,12 @@ export default class ClientInteractableManager {
      * @param relatedEntities - Related entities to view. These will always be collated into a string select menu interactable.
      * @param user - The user these interactables are being created for.
      */
-    async getViewInteractables<T extends PersistentGameEntity>(entity: T, fields: EntityField<T>[], relatedEntities: PersistentGameEntity[], user: User): Promise<Interactable[]> {
+    getViewInteractables<T extends PersistentGameEntity>(entity: T, fields: EntityField<T>[], relatedEntities: PersistentGameEntity[], user: User): Interactable[] {
         let interactables: Interactable[] = [];
         if (entity && fields.length > 0)
-            interactables = interactables.concat(await this.createViewFieldActionInteractables(entity, fields, user));
+            interactables = interactables.concat(this.createViewFieldActionInteractables(entity, fields, user));
         if (relatedEntities.length > 0)
-            interactables = interactables.concat(await this.createViewActionInteractables(relatedEntities, user));
+            interactables = interactables.concat(this.createViewActionInteractables(relatedEntities, user));
         return interactables;
     }
 }

--- a/Classes/ClientInteractionHandler.ts
+++ b/Classes/ClientInteractionHandler.ts
@@ -35,74 +35,74 @@ import type { Interaction, InteractionCallbackResponse } from "discord.js";
  * A set of functions for handling Interactions.
  */
 export default class ClientInteractionHandler {
-	/**
-	 * The game this belongs to.
-	 */
+    /**
+     * The game this belongs to.
+     */
     readonly #game: Game;
 
-	/**
-	 * @param game - The game this belongs to.
-	 */
-	constructor(game: Game) {
-		this.#game = game;
-	}
+    /**
+     * @param game - The game this belongs to.
+     */
+    constructor(game: Game) {
+        this.#game = game;
+    }
 
-	/**
-	 * Gets an interactable from the cache by the customId. If it doesn't exist, returns undefined.
-	 * @param customId
-	 */
-	getInteractable(customId: string): Interactable {
-		return this.#game.clientContext.interactableManager.getInteractableByCustomId(customId);
-	}
+    /**
+     * Gets an interactable from the cache by the customId. If it doesn't exist, returns undefined.
+     * @param customId
+     */
+    getInteractable(customId: string): Interactable {
+        return this.#game.clientContext.interactableManager.getInteractableByCustomId(customId);
+    }
 
-	/**
-	 * Intercepts an interaction event and directs it to the correct function.
-	 * @param interaction - The interaction that was created.
-	 */
-	interceptInteraction(interaction: Interaction): void {
+    /**
+     * Intercepts an interaction event and directs it to the correct function.
+     * @param interaction - The interaction that was created.
+     */
+    interceptInteraction(interaction: Interaction): void {
         const user = this.#game.entityFinder.getModeratorById(interaction.user.id) ?? this.#game.entityFinder.getLivingPlayerById(interaction.user.id);
-		if (!user) return;
-		if (interaction instanceof ButtonInteraction)
-			this.processButtonInteraction(interaction, user);
-		if (interaction instanceof StringSelectMenuInteraction)
-			this.processStringSelectMenuInteraction(interaction, user);
+        if (!user) return;
+        if (interaction instanceof ButtonInteraction)
+            this.processButtonInteraction(interaction, user);
+        if (interaction instanceof StringSelectMenuInteraction)
+            this.processStringSelectMenuInteraction(interaction, user);
         if (interaction instanceof ModalSubmitInteraction)
             this.processModalSubmitInteraction(interaction, user);
-		return;
-	}
+        return;
+    }
 
-	/**
-	 * Processes a button interaction.
-	 * @param interaction - The interaction being executed.
-	 * @param user - The user who triggered the interaction.
-	 */
-	processButtonInteraction(interaction: ButtonInteraction, user: User): void {
-		const customId = interaction.customId;
-		this.#processInteraction(customId, interaction, user);
-		return;
-	}
+    /**
+     * Processes a button interaction.
+     * @param interaction - The interaction being executed.
+     * @param user - The user who triggered the interaction.
+     */
+    processButtonInteraction(interaction: ButtonInteraction, user: User): void {
+        const customId = interaction.customId;
+        this.#processInteraction(customId, interaction, user);
+        return;
+    }
 
-	/**
-	 * Processes a string select interaction.
-	 * @param interaction - The interaction being executed.
-	 * @param user - The user who triggered the interaction.
-	 */
-	processStringSelectMenuInteraction(interaction: StringSelectMenuInteraction, user: User): void {
-		const selectedValue = interaction.values[0];
-		const customId = selectedValue;
-		this.#processInteraction(customId, interaction, user);
-		return;
-	}
+    /**
+     * Processes a string select interaction.
+     * @param interaction - The interaction being executed.
+     * @param user - The user who triggered the interaction.
+     */
+    processStringSelectMenuInteraction(interaction: StringSelectMenuInteraction, user: User): void {
+        const selectedValue = interaction.values[0];
+        const customId = selectedValue;
+        this.#processInteraction(customId, interaction, user);
+        return;
+    }
 
     /**
      * Processes a modal submit interaction.
      * @param interaction - The interaction being executed.
-	 * @param user - The user who triggered the interaction.
+     * @param user - The user who triggered the interaction.
      */
     processModalSubmitInteraction(interaction: ModalSubmitInteraction, user: User): void {
         const customId = interaction.customId;
-		this.#processInteraction(customId, interaction, user);
-		return;
+        this.#processInteraction(customId, interaction, user);
+        return;
     }
 
     /**
@@ -129,31 +129,31 @@ export default class ClientInteractionHandler {
                 errorMessage = error.message;
             }
         }
-		if (!successfullyProcessedInteractable) this.#replyToInteraction(errorMessage, interaction);
-		return;
+        if (!successfullyProcessedInteractable) this.#replyToInteraction(errorMessage, interaction);
+        return;
     }
 
-	/**
-	 * Process an interactable and calls the correct function.
+    /**
+     * Process an interactable and calls the correct function.
      * @param interactable - The interactable to process.
      * @param user - The user who triggered the interaction.
      * @param interaction - The interaction being executed.
-	 * @param reply - The reply that was sent.
-	 * @returns Whether the interactable successfully performed an action or not.
-	 */
-	async #processActionDirectiveInteractable(interactable: ActionDirectiveInteractable, user: User, interaction: BotInteraction, reply?: InteractionCallbackResponse<boolean>): Promise<boolean> {
+     * @param reply - The reply that was sent.
+     * @returns Whether the interactable successfully performed an action or not.
+     */
+    async #processActionDirectiveInteractable(interactable: ActionDirectiveInteractable, user: User, interaction: BotInteraction, reply?: InteractionCallbackResponse<boolean>): Promise<boolean> {
         const timestamp = new Date();
         const playerName = interactable.actionDirective.getPlayerName();
         const player = this.#game.entityFinder.getLivingPlayer(playerName);
         if (playerName && !player) throw new Error(`Invalid player.`);
         const author = user instanceof Moderator ? player ? `${player.name} (${user.member.user.username})` : user.member.user.username : player.name
         const forced = user instanceof Moderator;
-		const action = interactable.actionDirective.createAction(this.#game, undefined, player, player?.location, forced, undefined, user);
+        const action = interactable.actionDirective.createAction(this.#game, undefined, player, player?.location, forced, undefined, user);
         if (this.#game.editMode && !forced)
             return false;
-		if (action instanceof QueueMoveAction) {
-			const args = interactable.actionDirective.getArgs();
-			const parsedArgs = action.parseInteractionArgs(args);
+        if (action instanceof QueueMoveAction) {
+            const args = interactable.actionDirective.getArgs();
+            const parsedArgs = action.parseInteractionArgs(args);
             try {
                 const validatedArgs = action.validateInteractionArgs(parsedArgs);
                 if (validatedArgs.length === 2) {
@@ -164,7 +164,7 @@ export default class ClientInteractionHandler {
                 }
             }
             catch (error) { throw new Error(error.message); }
-		}
+        }
         if (action instanceof StopAction) {
             if (player && player.isMoving) {
                 action.performStop();
@@ -173,50 +173,50 @@ export default class ClientInteractionHandler {
                 return true;
             }
         }
-		if (action instanceof InspectAction) {
-			const args = interactable.actionDirective.getArgs();
-			const parsedArgs = action.parseInteractionArgs(args);
-			const validatedArgs = action.validateInteractionArgs(parsedArgs);
-			if (validatedArgs.length === 1) {
-				await action.performInspect(validatedArgs[0]);
-				this.#replyOrDeleteActionResponse(action, interaction, reply);
+        if (action instanceof InspectAction) {
+            const args = interactable.actionDirective.getArgs();
+            const parsedArgs = action.parseInteractionArgs(args);
+            const validatedArgs = action.validateInteractionArgs(parsedArgs);
+            if (validatedArgs.length === 1) {
+                action.performInspect(validatedArgs[0]);
+                this.#replyOrDeleteActionResponse(action, interaction, reply);
                 this.#logInteraction("InspectAction", author, timestamp, validatedArgs);
-				return true;
-			}
-		}
-		if (action instanceof TakeAction) {
-			const args = interactable.actionDirective.getArgs();
-			const parsedArgs = action.parseInteractionArgs(args);
-			const validatedArgs = action.validateInteractionArgs(parsedArgs);
-			if (validatedArgs.length === 4) {
-				await action.performTake(validatedArgs[0], validatedArgs[1], validatedArgs[2], validatedArgs[3]);
-				this.#replyOrDeleteActionResponse(action, interaction, reply);
+                return true;
+            }
+        }
+        if (action instanceof TakeAction) {
+            const args = interactable.actionDirective.getArgs();
+            const parsedArgs = action.parseInteractionArgs(args);
+            const validatedArgs = action.validateInteractionArgs(parsedArgs);
+            if (validatedArgs.length === 4) {
+                action.performTake(validatedArgs[0], validatedArgs[1], validatedArgs[2], validatedArgs[3]);
+                this.#replyOrDeleteActionResponse(action, interaction, reply);
                 this.#logInteraction("TakeAction", author, timestamp, validatedArgs);
-				return true;
-			}
-		}
-		if (action instanceof DropAction) {
-			const args = interactable.actionDirective.getArgs();
-			const parsedArgs = action.parseInteractionArgs(args);
-			const validatedArgs = action.validateInteractionArgs(parsedArgs);
-			if (validatedArgs.length === 4) {
-				await action.performDrop(validatedArgs[0], validatedArgs[1], validatedArgs[2], validatedArgs[3]);
-				this.#replyOrDeleteActionResponse(action, interaction, reply);
+                return true;
+            }
+        }
+        if (action instanceof DropAction) {
+            const args = interactable.actionDirective.getArgs();
+            const parsedArgs = action.parseInteractionArgs(args);
+            const validatedArgs = action.validateInteractionArgs(parsedArgs);
+            if (validatedArgs.length === 4) {
+                action.performDrop(validatedArgs[0], validatedArgs[1], validatedArgs[2], validatedArgs[3]);
+                this.#replyOrDeleteActionResponse(action, interaction, reply);
                 this.#logInteraction("DropAction", author, timestamp, validatedArgs);
-				return true;
-			}
-		}
-		if (action instanceof StashAction) {
-			const args = interactable.actionDirective.getArgs();
-			const parsedArgs = action.parseInteractionArgs(args);
-			const validatedArgs = action.validateInteractionArgs(parsedArgs);
-			if (validatedArgs.length === 4) {
-				action.performStash(validatedArgs[0], validatedArgs[1], validatedArgs[2], validatedArgs[3]);
-				this.#replyOrDeleteActionResponse(action, interaction, reply);
+                return true;
+            }
+        }
+        if (action instanceof StashAction) {
+            const args = interactable.actionDirective.getArgs();
+            const parsedArgs = action.parseInteractionArgs(args);
+            const validatedArgs = action.validateInteractionArgs(parsedArgs);
+            if (validatedArgs.length === 4) {
+                action.performStash(validatedArgs[0], validatedArgs[1], validatedArgs[2], validatedArgs[3]);
+                this.#replyOrDeleteActionResponse(action, interaction, reply);
                 this.#logInteraction("StashAction", author, timestamp, validatedArgs);
-				return true;
-			}
-		}
+                return true;
+            }
+        }
         if (action instanceof UnstashAction) {
             const args = interactable.actionDirective.getArgs();
             const parsedArgs = action.parseInteractionArgs(args);
@@ -255,7 +255,7 @@ export default class ClientInteractionHandler {
             const parsedArgs = action.parseInteractionArgs(args);
             const validatedArgs = action.validateInteractionArgs(parsedArgs);
             if (validatedArgs.length === 3) {
-                await action.performCraft(validatedArgs[0], validatedArgs[1], validatedArgs[2]);
+                action.performCraft(validatedArgs[0], validatedArgs[1], validatedArgs[2]);
                 this.#replyOrDeleteActionResponse(action, interaction, reply);
                 this.#logInteraction("CraftAction", author, timestamp, validatedArgs);
                 return true;
@@ -266,7 +266,7 @@ export default class ClientInteractionHandler {
             const parsedArgs = action.parseInteractionArgs(args);
             const validatedArgs = action.validateInteractionArgs(parsedArgs);
             if (validatedArgs.length === 2) {
-                await action.performUncraft(validatedArgs[0], validatedArgs[1]);
+                action.performUncraft(validatedArgs[0], validatedArgs[1]);
                 this.#replyOrDeleteActionResponse(action, interaction, reply);
                 this.#logInteraction("UncraftAction", author, timestamp, validatedArgs);
                 return true;
@@ -289,7 +289,7 @@ export default class ClientInteractionHandler {
             try {
                 const validatedArgs = action.validateInteractionArgs(parsedArgs);
                 if (validatedArgs.length === 2) {
-                    await action.performActivate(validatedArgs[0], validatedArgs[1]);
+                    action.performActivate(validatedArgs[0], validatedArgs[1]);
                     this.#replyOrDeleteActionResponse(action, interaction, reply);
                     this.#logInteraction("ActivateAction", author, timestamp, validatedArgs);
                     return true;
@@ -303,7 +303,7 @@ export default class ClientInteractionHandler {
             try {
                 const validatedArgs = action.validateInteractionArgs(parsedArgs);
                 if (validatedArgs.length === 2) {
-                    await action.performDeactivate(validatedArgs[0], validatedArgs[1]);
+                    action.performDeactivate(validatedArgs[0], validatedArgs[1]);
                     this.#replyOrDeleteActionResponse(action, interaction, reply);
                     this.#logInteraction("DeactivateAction", author, timestamp, validatedArgs);
                     return true;
@@ -333,7 +333,7 @@ export default class ClientInteractionHandler {
             else {
                 const args = interactable.actionDirective.getArgs();
                 if (args.length === 5 && args[0] === "II") {
-                    const modal = await this.#game.clientContext.interactableManager.createInstantiateInventoryItemActionModalInteractable(args as [string, string, string, string], player, user);
+                    const modal = this.#game.clientContext.interactableManager.createInstantiateInventoryItemActionModalInteractable(args as [string, string, string, string], player, user);
                     await interaction.showModal(modal.component);
                     return true;
                 }
@@ -361,7 +361,7 @@ export default class ClientInteractionHandler {
             else {
                 const args = interactable.actionDirective.getArgs();
                 if (args.length >= 4 && (args[0] === "F" || args[0] === "RI" || args[0] === "PZ")) {
-                    const modal = await this.#game.clientContext.interactableManager.createInstantiateRoomItemActionModalInteractable(args, user);
+                    const modal = this.#game.clientContext.interactableManager.createInstantiateRoomItemActionModalInteractable(args, user);
                     await interaction.showModal(modal.component);
                     return true;
                 }
@@ -418,21 +418,21 @@ export default class ClientInteractionHandler {
             const parsedArgs = action.parseInteractionArgs(args);
             try {
                 const validatedArgs = action.validateInteractionArgs(parsedArgs);
-                await action.performView(validatedArgs[0], validatedArgs[1]);
+                action.performView(validatedArgs[0], validatedArgs[1]);
                 if (reply) reply.resource.message.delete();
                 return true;
             }
             catch (error) { throw new Error(error.message); }
         }
-		return false;
-	}
+        return false;
+    }
 
     /**
      * Processes a standard interactable, i.e. an interactable that doesn't contain an action directive.
      * @param interactable - The interactable to process.
      * @param user - The user who triggered the interaction.
      * @param interaction - The interaction being executed.
-	 * @param reply - The reply that was sent.
+     * @param reply - The reply that was sent.
      * @returns Whether the interactable successfully performed an action or not.
      */
     async #processStandardInteractable(interactable: Interactable, user: User, interaction: BotInteraction, reply?: InteractionCallbackResponse<boolean>): Promise<boolean> {
@@ -441,29 +441,29 @@ export default class ClientInteractionHandler {
             interactable.callback(interaction);
             if (reply) reply.resource.message.delete();
         }
-       return true;
+        return true;
     }
 
     /**
      * Replies to the interaction if it was initiated by a moderator. Otherwise, deletes the deferred response.
      * @param action - The action that was performed.
      * @param interaction - The interaction being executed.
-	 * @param reply - The reply that was sent.
+     * @param reply - The reply that was sent.
      */
     #replyOrDeleteActionResponse(action: Action, interaction: BotInteraction, reply?: InteractionCallbackResponse<boolean>) {
         if (action.forced && action.successMessage) this.#replyToInteraction(action.successMessage, interaction);
         else if (reply) reply.resource.message.delete();
     }
 
-	/**
-	 * Replies to an interaction.
-	 * @param response - The response to send.
-	 * @param interaction - The interaction to reply to.
-	 */
-	#replyToInteraction(response: string, interaction: BotInteraction): void {
+    /**
+     * Replies to an interaction.
+     * @param response - The response to send.
+     * @param interaction - The interaction to reply to.
+     */
+    #replyToInteraction(response: string, interaction: BotInteraction): void {
         if (interaction.replied || interaction.deferred) interaction.editReply({ content: response });
         else interaction.reply({ content: response });
-	}
+    }
 
     /**
      * Logs the occurrence of an interaction.

--- a/Classes/GameNarrationHandler.ts
+++ b/Classes/GameNarrationHandler.ts
@@ -207,7 +207,7 @@ export default class GameNarrationHandler {
      * @param entrance - The exit the player will enter the destination room from.
      * @param isMovingFreely - Whether or not the player is performing free movement.
      */
-    async narrateEnter(action: Action, player: Player, destinationRoom: Room, entrance: Exit, isMovingFreely: boolean) {
+    narrateEnter(action: Action, player: Player, destinationRoom: Room, entrance: Exit, isMovingFreely: boolean) {
         const messageType = MessageDisplayType.STANDARD;
         const entrancePhrase = entrance?.getNamePhrase();
         const appendString = player.createMoveAppendString();
@@ -220,7 +220,7 @@ export default class GameNarrationHandler {
         }
         else {
             const description = entrance ? entrance.description : destinationRoom.description;
-            await description.parseAndSendTo(player, destinationRoom);
+            description.parseAndSendTo(player, destinationRoom);
         }
     }
 

--- a/Data/Actions/ActivateAction.ts
+++ b/Data/Actions/ActivateAction.ts
@@ -20,7 +20,7 @@ export default class ActivateAction extends Action {
      * @param narrate - Whether or not to narrate the fixture's activation.
      * @param customNarration - The custom text of the narration. Optional.
      */
-    async performActivate(fixture: Fixture, narrate: boolean, customNarration?: string): Promise<void> {
+    performActivate(fixture: Fixture, narrate: boolean, customNarration?: string): void {
         if (this.performed) return;
         super.perform();
         this.getGame().logHandler.logActivate(fixture, this.player, this.forced);
@@ -31,7 +31,7 @@ export default class ActivateAction extends Action {
             initiatedDescription = fixture.process.recipe.initiatedDescription.parseFor(this.player, fixture);
             messageDisplayType = fixture.process.recipe.initiatedDescription.messageDisplayType;
         }
-        const interactables = await this.#getInteractables(fixture);
+        const interactables = this.#getInteractables(fixture);
         if (narrate)
             this.getGame().narrationHandler.narrateActivate(this, fixture, this.player, initiatedDescription !== undefined && initiatedDescription !== "", customNarration, interactables);
         if (initiatedDescription) {
@@ -40,11 +40,11 @@ export default class ActivateAction extends Action {
         this.successMessage = `Successfully activated ${fixture.name} at ${fixture.location.getEntityID()}${this.player ? ` for ${this.player.name}` : ``}.`;
     }
 
-    async #getInteractables(fixture: Fixture): Promise<Interactable[]> {
+    #getInteractables(fixture: Fixture): Interactable[] {
         let interactables: Interactable[] = [];
         const interactableManager = this.getGame().clientContext.interactableManager;
-        interactables = interactables.concat(await interactableManager.createInspectActionInteractable([fixture], this.player));
-        interactables = interactables.concat(await interactableManager.getActivateOrDeactivateInteractables(fixture, this.player, true));
+        interactables = interactables.concat(interactableManager.createInspectActionInteractable([fixture], this.player));
+        interactables = interactables.concat(interactableManager.getActivateOrDeactivateInteractables(fixture, this.player, true));
         return interactables;
     }
 

--- a/Data/Actions/CraftAction.ts
+++ b/Data/Actions/CraftAction.ts
@@ -21,7 +21,7 @@ export default class CraftAction extends Action {
      * @param item2 - The second ingredient.
      * @param recipe - The recipe that describes how these ingredients are crafted.
      */
-    async performCraft(item1: InventoryItem, item2: InventoryItem, recipe: Recipe): Promise<void> {
+    performCraft(item1: InventoryItem, item2: InventoryItem, recipe: Recipe): void {
         if (this.performed) return;
         super.perform();
         const item1Id = item1.getIdentifier();
@@ -29,7 +29,7 @@ export default class CraftAction extends Action {
         const craftingResult = this.player.craft(recipe);
         const completedDescription = recipe.completedDescription.parseFor(this.player, this.player);
         const createdItems = [craftingResult.product1, craftingResult.product2].filter(item => item !== null);
-        const interactables = await this.#getInteractables(createdItems);
+        const interactables = this.#getInteractables(createdItems);
         this.player.sendDescription(completedDescription, this.player, recipe.completedDescription.messageDisplayType ?? MessageDisplayType.STANDARD, interactables);
         this.getGame().narrationHandler.narrateCraft(this, craftingResult, this.player);
         this.getGame().logHandler.logCraft(item1Id, item2Id, craftingResult, this.player, this.forced);
@@ -37,13 +37,13 @@ export default class CraftAction extends Action {
         this.successMessage = `Successfully crafted ${item1Id} and ${item2Id} for ${this.player.name}.`;
     }
 
-    async #getInteractables(createdItems: InventoryItem[]): Promise<Interactable[]> {
+    #getInteractables(createdItems: InventoryItem[]): Interactable[] {
         let interactables: Interactable[] = [];
         const interactableManager = this.getGame().clientContext.interactableManager;
-        interactables = interactables.concat(await interactableManager.createInspectActionInteractable(createdItems, this.player))
-        interactables = interactables.concat(await interactableManager.getCraftInteractables(this.player));
-        interactables = interactables.concat(await interactableManager.getUncraftInteractables(this.player, this.user));
-        interactables = interactables.concat(await interactableManager.getUseInteractables(this.player));
+        interactables = interactables.concat(interactableManager.createInspectActionInteractable(createdItems, this.player))
+        interactables = interactables.concat(interactableManager.getCraftInteractables(this.player));
+        interactables = interactables.concat(interactableManager.getUncraftInteractables(this.player, this.user));
+        interactables = interactables.concat(interactableManager.getUseInteractables(this.player));
         return interactables;
     }
 

--- a/Data/Actions/DeactivateAction.ts
+++ b/Data/Actions/DeactivateAction.ts
@@ -19,11 +19,11 @@ export default class DeactivateAction extends Action {
      * @param narrate - Whether or not to narrate the fixture's deactivation.
      * @param customNarration - The custom text of the narration. Optional.
      */
-    async performDeactivate(fixture: Fixture, narrate: boolean, customNarration?: string): Promise<void> {
+    performDeactivate(fixture: Fixture, narrate: boolean, customNarration?: string): void {
         if (this.performed) return;
         super.perform();
         const player = this.player && this.player.location.id === fixture.location.id && this.player.isConscious() && !this.player.isHidden() ? this.player : undefined;
-        const interactables = player ? await this.#getInteractables(fixture) : [];
+        const interactables = player ? this.#getInteractables(fixture) : [];
         if (narrate)
             this.getGame().narrationHandler.narrateDeactivate(this, fixture, player, customNarration, interactables);
         this.getGame().logHandler.logDeactivate(fixture, player, this.forced);
@@ -31,11 +31,11 @@ export default class DeactivateAction extends Action {
         this.successMessage = `Successfully deactivated ${fixture.name} at ${fixture.location.getEntityID()}${this.player ? ` for ${this.player.name}` : ``}.`;
     }
 
-    async #getInteractables(fixture: Fixture): Promise<Interactable[]> {
+    #getInteractables(fixture: Fixture): Interactable[] {
         let interactables: Interactable[] = [];
         const interactableManager = this.getGame().clientContext.interactableManager;
-        interactables = interactables.concat(await interactableManager.createInspectActionInteractable([fixture], this.player));
-        interactables = interactables.concat(await interactableManager.getActivateOrDeactivateInteractables(fixture, this.player, false));
+        interactables = interactables.concat(interactableManager.createInspectActionInteractable([fixture], this.player));
+        interactables = interactables.concat(interactableManager.getActivateOrDeactivateInteractables(fixture, this.player, false));
         return interactables;
     }
 

--- a/Data/Actions/DropAction.ts
+++ b/Data/Actions/DropAction.ts
@@ -28,10 +28,10 @@ export default class DropAction extends Action {
      * @param inventorySlot - The {@link InventorySlot|inventory slot} to put the item in.
      * @param notify - Whether or not to notify the player that they dropped the item. Defaults to true.
      */
-    async performDrop(item: InventoryItem, handEquipmentSlot: EquipmentSlot, container: RoomItemContainer, inventorySlot: InventorySlot<RoomItem>, notify: boolean = true): Promise<void> {
+    performDrop(item: InventoryItem, handEquipmentSlot: EquipmentSlot, container: RoomItemContainer, inventorySlot: InventorySlot<RoomItem>, notify: boolean = true): void {
         if (this.performed) return;
         super.perform();
-        const interactables = await this.#getInteractables(container);
+        const interactables = this.#getInteractables(container);
         this.getGame().narrationHandler.narrateDrop(this, item, container, this.player, notify, interactables);
         this.getGame().logHandler.logDrop(item, this.player, container, inventorySlot, this.forced);
         this.player.drop(item, handEquipmentSlot, container, inventorySlot);
@@ -58,10 +58,10 @@ export default class DropAction extends Action {
         this.successMessage = `Successfully dropped ${item.getIdentifier()} ${preposition} ${containerPhrase} for ${this.player.name}.`;
     }
 
-    async #getInteractables(container: RoomItemContainer): Promise<Interactable[]> {
+    #getInteractables(container: RoomItemContainer): Interactable[] {
         let interactables: Interactable[] = [];
         if (container instanceof Fixture) {
-            interactables = interactables.concat(await this.getGame().clientContext.interactableManager.getActivateOrDeactivateInteractables(container, this.player));
+            interactables = interactables.concat(this.getGame().clientContext.interactableManager.getActivateOrDeactivateInteractables(container, this.player));
         }
         return interactables;
     }

--- a/Data/Actions/EnterAction.ts
+++ b/Data/Actions/EnterAction.ts
@@ -13,19 +13,19 @@ import QueueMoveAction from "./QueueMoveAction.ts";
  * @see https://msvblank.github.io/Alter-Ego/reference/data_structures/action.html#enter-action
  */
 export default class EnterAction extends Action {
-	/**
-	 * Performs an enter action.
+    /**
+     * Performs an enter action.
      *
-	 * @param destinationRoom - The room the player will be moved to.
-	 * @param entrance - The exit the player will enter the destination room from.
-	 * @param isMovingFreely - Whether or not the player is performing free movement.
+     * @param destinationRoom - The room the player will be moved to.
+     * @param entrance - The exit the player will enter the destination room from.
+     * @param isMovingFreely - Whether or not the player is performing free movement.
      * @param isRunning - Whether the player is running. False by default.
-	 */
-	async performEnter(destinationRoom: Room, entrance: Exit, isMovingFreely: boolean, isRunning: boolean = false): Promise<void> {
-		if (this.performed) return;
-		super.perform();
-		destinationRoom.addPlayer(this.player, entrance);
-		await this.getGame().narrationHandler.narrateEnter(this, this.player, destinationRoom, entrance, isMovingFreely);
+     */
+    async performEnter(destinationRoom: Room, entrance: Exit, isMovingFreely: boolean, isRunning: boolean = false): Promise<void> {
+        if (this.performed) return;
+        super.perform();
+        destinationRoom.addPlayer(this.player, entrance);
+        this.getGame().narrationHandler.narrateEnter(this, this.player, destinationRoom, entrance, isMovingFreely);
         this.player.moveQueue.splice(0, 1);
         const followedPlayer = this.player.followedPlayer;
         if (!followedPlayer && this.player.moveQueue.length > 0) {
@@ -47,5 +47,5 @@ export default class EnterAction extends Action {
             const queueMoveAction = new QueueMoveAction(this.getGame(), undefined, this.player, this.player.location, this.forced);
             await queueMoveAction.performQueueMove(followedPlayer.isRunning, this.player.moveQueue[0], this.player.getFollowingSpeed());
         }
-	}
+    }
 }

--- a/Data/Actions/FindAction.ts
+++ b/Data/Actions/FindAction.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Ms. VBLANK <alteregomolly@pm.me>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import type { ButtonInteraction } from "discord.js";
 import Action from "../Action.ts";
 import type Event from "../Event.ts";
@@ -419,7 +423,7 @@ export default class FindAction extends Action {
     /**
      * Sends the result list message and edits it when the user requests the next or previous page.
      */
-    async #sendResultListMessage<T extends PersistentGameEntity>(results: T[]): Promise<void> {
+    #sendResultListMessage<T extends PersistentGameEntity>(results: T[]): void {
         const pages = this.#createResultPages(results);
         let page = 0;
         const resultCountString = `Found ${results.length} result${results.length === 1 ? '' : 's'}.`;
@@ -445,22 +449,22 @@ export default class FindAction extends Action {
             interactables = interactables.concat(this.getGame().clientContext.interactableManager.createPaginationInteractables(this, prevPageCallback, nextPageCallback));
         }
         else {
-            interactables = interactables.concat(await this.#getInteractables(results));
+            interactables = interactables.concat(this.#getInteractables(results));
         }
         this.getGame().communicationHandler.sendToChannel(this.getGame().guildContext.commandChannel, resultCountString + pageString + resultsDisplay, [], interactables);
     }
 
-    async #getInteractables<T extends PersistentGameEntity>(results: T[]): Promise<Interactable[]> {
+    #getInteractables<T extends PersistentGameEntity>(results: T[]): Interactable[] {
         let interactables: Interactable[] = [];
         const interactableManager = this.getGame().clientContext.interactableManager;
-        interactables = await interactableManager.getViewInteractables(undefined, [], results, this.user);
+        interactables = interactableManager.getViewInteractables(undefined, [], results, this.user);
         if (results.every(result => result instanceof Fixture || result instanceof RoomItem || result instanceof Puzzle)) {
-            interactables = interactables.concat(await interactableManager.getInstantiateRoomItemInteractables(results, this.user));
-            interactables = interactables.concat(await interactableManager.getDestroyRoomItemInteractables(results, this.user));
+            interactables = interactables.concat(interactableManager.getInstantiateRoomItemInteractables(results, this.user));
+            interactables = interactables.concat(interactableManager.getDestroyRoomItemInteractables(results, this.user));
         }
         else if (results.every(result => result instanceof InventoryItem)) {
-            interactables = interactables.concat(await interactableManager.getInstantiateInventoryItemInteractables(undefined, this.user, [], results));
-            interactables = interactables.concat(await interactableManager.createDestroyInventoryItemActionInteractables(results, undefined, this.user));
+            interactables = interactables.concat(interactableManager.getInstantiateInventoryItemInteractables(undefined, this.user, [], results));
+            interactables = interactables.concat(interactableManager.createDestroyInventoryItemActionInteractables(results, undefined, this.user));
         }
         return interactables;
     }

--- a/Data/Actions/InspectAction.ts
+++ b/Data/Actions/InspectAction.ts
@@ -19,7 +19,7 @@ export default class InspectAction extends Action {
      *
      * @param target - The entity to inspect.
      */
-    async performInspect(target: Inspectable): Promise<void> {
+    performInspect(target: Inspectable): void {
         if (this.performed) return;
         super.perform();
         this.getGame().narrationHandler.narrateInspect(this, target, this.player);

--- a/Data/Actions/InventoryAction.ts
+++ b/Data/Actions/InventoryAction.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2019 Alter Ego Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import type Interactable from "../../Classes/Interactables/Interactable.ts";
 import Action from "../Action.ts";
 
@@ -7,39 +11,39 @@ import Action from "../Action.ts";
  * @see https://msvblank.github.io/Alter-Ego/reference/data_structures/action.html#inventory-action
  */
 export default class InventoryAction extends Action {
-	/**
-	 * Performs an inventory action.
-	 */
-	async performInventory(): Promise<void> {
-		if (this.performed) return;
-		super.perform();
-		const inventoryString = this.player.viewInventory(this.forced);
-		const interactables = await this.#getInteractables();
+    /**
+     * Performs an inventory action.
+     */
+    performInventory(): void {
+        if (this.performed) return;
+        super.perform();
+        const inventoryString = this.player.viewInventory(this.forced);
+        const interactables = this.#getInteractables();
 
-		if (this.forced)
-			this.getGame().communicationHandler.sendToCommandChannel(inventoryString, interactables);
-		else
-			this.getGame().communicationHandler.sendMessageToPlayer(this.player, inventoryString, true, undefined, undefined, interactables);
-	}
+        if (this.forced)
+            this.getGame().communicationHandler.sendToCommandChannel(inventoryString, interactables);
+        else
+            this.getGame().communicationHandler.sendMessageToPlayer(this.player, inventoryString, true, undefined, undefined, interactables);
+    }
 
-    async #getInteractables(): Promise<Interactable[]> {
+    #getInteractables(): Interactable[] {
         let interactables: Interactable[] = [];
         const interactableManager = this.getGame().clientContext.interactableManager;
         if (this.forced) {
-            interactables = interactables.concat(await interactableManager.getInstantiateInventoryItemInteractables(this.player, this.user));
-            interactables = interactables.concat(await interactableManager.getDestroyInventoryItemInteractables(this.player, this.user));
+            interactables = interactables.concat(interactableManager.getInstantiateInventoryItemInteractables(this.player, this.user));
+            interactables = interactables.concat(interactableManager.getDestroyInventoryItemInteractables(this.player, this.user));
         }
         else {
             const inventoryItems = this.player.getContainedItems().toSorted((a, b) => this.player.getEquipmentSlot(a.equipmentSlot).row - this.player.getEquipmentSlot(b.equipmentSlot).row);
-            interactables = interactables.concat(await interactableManager.createInspectActionInteractable(inventoryItems, this.player, this.user));
+            interactables = interactables.concat(interactableManager.createInspectActionInteractable(inventoryItems, this.player, this.user));
         }
-        interactables = interactables.concat(await interactableManager.getStashInteractables(this.player, this.user));
-        interactables = interactables.concat(await interactableManager.getUnstashInteractables(this.player, this.user));
-        interactables = interactables.concat(await interactableManager.getCraftInteractables(this.player, this.user));
-        interactables = interactables.concat(await interactableManager.getUncraftInteractables(this.player, this.user));
-        interactables = interactables.concat(await interactableManager.getUseInteractables(this.player, this.user));
-        interactables = interactables.concat(await interactableManager.getEquipInteractables(this.player, this.user));
-        interactables = interactables.concat(await interactableManager.getUnequipInteractables(this.player, this.user));
+        interactables = interactables.concat(interactableManager.getStashInteractables(this.player, this.user));
+        interactables = interactables.concat(interactableManager.getUnstashInteractables(this.player, this.user));
+        interactables = interactables.concat(interactableManager.getCraftInteractables(this.player, this.user));
+        interactables = interactables.concat(interactableManager.getUncraftInteractables(this.player, this.user));
+        interactables = interactables.concat(interactableManager.getUseInteractables(this.player, this.user));
+        interactables = interactables.concat(interactableManager.getEquipInteractables(this.player, this.user));
+        interactables = interactables.concat(interactableManager.getUnequipInteractables(this.player, this.user));
         return interactables;
     }
 }

--- a/Data/Actions/RecipesAction.ts
+++ b/Data/Actions/RecipesAction.ts
@@ -40,7 +40,7 @@ export default class RecipesAction extends Action {
      *
      * @param item - An inventory item to use as one of the ingredients. If this is provided, all recipes that use it as an ingredient will be shown.
      */
-    async performRecipes(item?: InventoryItem): Promise<void> {
+    performRecipes(item?: InventoryItem): void {
         if (this.performed) return;
         super.perform();
 

--- a/Data/Actions/StartMoveAction.ts
+++ b/Data/Actions/StartMoveAction.ts
@@ -14,30 +14,28 @@ import QueueMoveAction from "./QueueMoveAction.ts";
  * @see https://msvblank.github.io/Alter-Ego/reference/data_structures/action.html#start-move-action
  */
 export default class StartMoveAction extends Action {
-	/**
-	 * Performs a start move action.
+    /**
+     * Performs a start move action.
      *
-	 * @param isRunning - Whether the player is running.
+     * @param isRunning - Whether the player is running.
      * @param currentRoom - The room the player is currently in.
      * @param destinationRoom - The room the player will be moved to.
      * @param exit - The exit the player will leave their current room through.
      * @param entrance - The exit the player will enter the destination room from.
      * @param speed - The speed at which the player is moving. Defaults to the minimum speed of their party, or their own current speed if they're not in a party.
-	 */
-	async performStartMove(isRunning: boolean, currentRoom: Room, destinationRoom: Room, exit: Exit, entrance: Exit, speed = this.player.party ? this.player.party.speed : this.player.speed): Promise<void> {
-		if (this.performed) return;
-		super.perform();
+     */
+    async performStartMove(isRunning: boolean, currentRoom: Room, destinationRoom: Room, exit: Exit, entrance: Exit, speed = this.player.party ? this.player.party.speed : this.player.speed): Promise<void> {
+        if (this.performed) return;
+        super.perform();
         this.player.currentMovingSpeed = speed;
-		const time = this.player.calculateMoveTime(exit, isRunning, speed);
+        const time = this.player.calculateMoveTime(exit, isRunning, speed);
         /**
          * Ordinarily, we narrate actions before performing them to avoid changes to the state before the narration is created,
          * but since this narration only occurs if the movement is going to take longer than 1000ms, we don't have to worry about that.
-         * It's important to begin the movement before sending the narration in this case, as creating interactables involves
-         * async operations that can cause race conditions when using fake timers in tests.
          */
-		this.player.move(isRunning, currentRoom, destinationRoom, exit, entrance, time, this.forced);
-		if (time > 1000) {
-            const interactables = await this.getGame().clientContext.interactableManager.createStopActionInteractable(this.player, this.user);
+        this.player.move(isRunning, currentRoom, destinationRoom, exit, entrance, time, this.forced);
+        if (time > 1000) {
+            const interactables = this.getGame().clientContext.interactableManager.createStopActionInteractable(this.player, this.user);
             this.getGame().narrationHandler.narrateStartMove(this, isRunning, exit, this.player, interactables);
         }
 
@@ -58,5 +56,5 @@ export default class StartMoveAction extends Action {
                 });
             }
         }
-	}
+    }
 }

--- a/Data/Actions/StartMoveAction.ts
+++ b/Data/Actions/StartMoveAction.ts
@@ -29,15 +29,11 @@ export default class StartMoveAction extends Action {
         super.perform();
         this.player.currentMovingSpeed = speed;
         const time = this.player.calculateMoveTime(exit, isRunning, speed);
-        /**
-         * Ordinarily, we narrate actions before performing them to avoid changes to the state before the narration is created,
-         * but since this narration only occurs if the movement is going to take longer than 1000ms, we don't have to worry about that.
-         */
-        this.player.move(isRunning, currentRoom, destinationRoom, exit, entrance, time, this.forced);
         if (time > 1000) {
             const interactables = this.getGame().clientContext.interactableManager.createStopActionInteractable(this.player, this.user);
             this.getGame().narrationHandler.narrateStartMove(this, isRunning, exit, this.player, interactables);
         }
+        this.player.move(isRunning, currentRoom, destinationRoom, exit, entrance, time, this.forced);
 
         // If anyone is following this player, they need to start moving.
         for (const occupant of this.location.occupants) {

--- a/Data/Actions/TakeAction.ts
+++ b/Data/Actions/TakeAction.ts
@@ -27,7 +27,7 @@ export default class TakeAction extends Action {
      * @param inventorySlot - The {@link InventorySlot|inventory slot} the item is currently in.
      * @param notify - Whether or not to notify the player that they took the item. Defaults to true.
      */
-    async performTake(item: RoomItem, handEquipmentSlot: EquipmentSlot, container: RoomItemContainer, inventorySlot: InventorySlot<RoomItem>, notify: boolean = true): Promise<void> {
+    performTake(item: RoomItem, handEquipmentSlot: EquipmentSlot, container: RoomItemContainer, inventorySlot: InventorySlot<RoomItem>, notify: boolean = true): void {
         if (this.performed) return;
         super.perform();
         const successful = this.forced || this.player.carryWeight + item.weight <= this.player.maxCarryWeight;
@@ -37,7 +37,7 @@ export default class TakeAction extends Action {
             return;
         }
         const takenItem = this.player.take(item, handEquipmentSlot, container, inventorySlot);
-        const interactables = await this.#getInteractables();
+        const interactables = this.#getInteractables();
         this.getGame().narrationHandler.narrateTake(this, takenItem, container, this.player, notify, interactables);
         // Container is a weight puzzle.
         if (container instanceof Puzzle && container.type === "weight") {
@@ -61,13 +61,13 @@ export default class TakeAction extends Action {
         this.successMessage = `Successfully took ${item.getIdentifier()} from ${slotPhrase}${container.getEntityID()} for ${this.player.name}.`;
     }
 
-    async #getInteractables(): Promise<Interactable[]> {
-        let interactables = await this.getGame().clientContext.interactableManager.getStashInteractables(this.player);
+    #getInteractables(): Interactable[] {
+        let interactables = this.getGame().clientContext.interactableManager.getStashInteractables(this.player);
         const interactableManager = this.getGame().clientContext.interactableManager;
-        interactables = interactables.concat(await interactableManager.getCraftInteractables(this.player));
-        interactables = interactables.concat(await interactableManager.getUncraftInteractables(this.player, this.user));
-        interactables = interactables.concat(await interactableManager.getUseInteractables(this.player));
-        interactables = interactables.concat(await interactableManager.getEquipInteractables(this.player));
+        interactables = interactables.concat(interactableManager.getCraftInteractables(this.player));
+        interactables = interactables.concat(interactableManager.getUncraftInteractables(this.player, this.user));
+        interactables = interactables.concat(interactableManager.getUseInteractables(this.player));
+        interactables = interactables.concat(interactableManager.getEquipInteractables(this.player));
         return interactables;
     }
 

--- a/Data/Actions/UncraftAction.ts
+++ b/Data/Actions/UncraftAction.ts
@@ -20,7 +20,7 @@ export default class UncraftAction extends Action {
      * @param item - The product to uncraft.
      * @param recipe - The recipe that describes how this product is crafted.
      */
-    async performUncraft(item: InventoryItem, recipe: Recipe): Promise<void> {
+    performUncraft(item: InventoryItem, recipe: Recipe): void {
         if (this.performed) return;
         super.perform();
         const originalItemDiscreet = item.prefab.discreet;
@@ -28,7 +28,7 @@ export default class UncraftAction extends Action {
         const itemId = item.getIdentifier();
         const uncraftingResult = this.player.uncraft(item, recipe);
         const uncraftedDescription = recipe.uncraftedDescription.parseFor(this.player, this.player);
-        const interactables = await this.#getInteractables([uncraftingResult.ingredient1, uncraftingResult.ingredient2].filter(ingredient => ingredient !== null));
+        const interactables = this.#getInteractables([uncraftingResult.ingredient1, uncraftingResult.ingredient2].filter(ingredient => ingredient !== null));
         this.player.sendDescription(uncraftedDescription, this.player, recipe.uncraftedDescription.messageDisplayType ?? MessageDisplayType.STANDARD, interactables);
         this.getGame().narrationHandler.narrateUncraft(this, recipe, originalItemDiscreet, originalItemSingleContainingPhrase, item, uncraftingResult, this.player);
         this.getGame().logHandler.logUncraft(itemId, uncraftingResult, this.player, this.forced);
@@ -36,12 +36,12 @@ export default class UncraftAction extends Action {
         this.successMessage = `Successfully uncrafted ${itemId} for ${this.player.name}.`;
     }
 
-    async #getInteractables(createdItems: InventoryItem[]): Promise<Interactable[]> {
+    #getInteractables(createdItems: InventoryItem[]): Interactable[] {
         let interactables: Interactable[] = [];
         const interactableManager = this.getGame().clientContext.interactableManager;
-        interactables = interactables.concat(await interactableManager.createInspectActionInteractable(createdItems, this.player))
-        interactables = interactables.concat(await interactableManager.getCraftInteractables(this.player));
-        interactables = interactables.concat(await interactableManager.getUseInteractables(this.player));
+        interactables = interactables.concat(interactableManager.createInspectActionInteractable(createdItems, this.player))
+        interactables = interactables.concat(interactableManager.getCraftInteractables(this.player));
+        interactables = interactables.concat(interactableManager.getUseInteractables(this.player));
         return interactables;
     }
 

--- a/Data/Actions/UndressAction.ts
+++ b/Data/Actions/UndressAction.ts
@@ -18,59 +18,59 @@ import DropAction from "./DropAction.ts";
  * @see https://msvblank.github.io/Alter-Ego/reference/data_structures/action.html#undress-action
  */
 export default class UndressAction extends Action {
-	/**
-	 * Performs an undress action.
+    /**
+     * Performs an undress action.
      *
-	 * @param container - The container to put the items in.
-	 * @param inventorySlot - The inventory slot to put the items in, if applicable.
-	 */
-	async performUndress(container: Puzzle | Fixture | RoomItem, inventorySlot: InventorySlot<RoomItem>): Promise<void> {
-		if (this.performed) return;
-		super.perform();
-		// First, drop the items in the player's hands.
-		const rightHand = this.player.inventory.get("RIGHT HAND");
-		const leftHand = this.player.inventory.get("LEFT HAND");
-		if (rightHand && rightHand.equippedItem !== null) {
-			const rightHandDropAction = new DropAction(this.getGame(), undefined, this.player, this.location, this.forced);
-			await rightHandDropAction.performDrop(rightHand.equippedItem, rightHand, container, inventorySlot, true);
-		}
-		if (leftHand && leftHand.equippedItem !== null) {
-			const leftHandDropAction = new DropAction(this.getGame(), undefined, this.player, this.location, this.forced);
-			await leftHandDropAction.performDrop(leftHand.equippedItem, leftHand, container, inventorySlot, true);
-		}
-		const droppedItems: InventoryItem[] = [];
-		for (const equipmentSlot of this.player.inventory.values()) {
-			if (equipmentSlot.equippedItem !== null && equipmentSlot.equippedItem.prefab.equippable) {
+     * @param container - The container to put the items in.
+     * @param inventorySlot - The inventory slot to put the items in, if applicable.
+     */
+    performUndress(container: Puzzle | Fixture | RoomItem, inventorySlot: InventorySlot<RoomItem>): void {
+        if (this.performed) return;
+        super.perform();
+        // First, drop the items in the player's hands.
+        const rightHand = this.player.inventory.get("RIGHT HAND");
+        const leftHand = this.player.inventory.get("LEFT HAND");
+        if (rightHand && rightHand.equippedItem !== null) {
+            const rightHandDropAction = new DropAction(this.getGame(), undefined, this.player, this.location, this.forced);
+            rightHandDropAction.performDrop(rightHand.equippedItem, rightHand, container, inventorySlot, true);
+        }
+        if (leftHand && leftHand.equippedItem !== null) {
+            const leftHandDropAction = new DropAction(this.getGame(), undefined, this.player, this.location, this.forced);
+            leftHandDropAction.performDrop(leftHand.equippedItem, leftHand, container, inventorySlot, true);
+        }
+        const droppedItems: InventoryItem[] = [];
+        for (const equipmentSlot of this.player.inventory.values()) {
+            if (equipmentSlot.equippedItem !== null && equipmentSlot.equippedItem.prefab.equippable) {
                 const droppedItem = equipmentSlot.equippedItem;
-				droppedItems.push(droppedItem);
-				this.player.unequip(equipmentSlot.equippedItem, equipmentSlot, rightHand);
-				this.player.drop(rightHand.equippedItem, rightHand, container, inventorySlot);
+                droppedItems.push(droppedItem);
+                this.player.unequip(equipmentSlot.equippedItem, equipmentSlot, rightHand);
+                this.player.drop(rightHand.equippedItem, rightHand, container, inventorySlot);
                 // Container is a drop puzzle.
                 if (container instanceof Puzzle && container.type === "drop") {
                     const attemptAction = new AttemptAction(this.getGame(), undefined, this.player, this.location, this.forced);
                     attemptAction.performAttempt(container, droppedItem, droppedItem.getIdentifier(), "drop", "");
                 }
-			}
-		}
-		this.getGame().narrationHandler.narrateUndress(this, droppedItems, container, this.player);
-		this.getGame().logHandler.logUndress(droppedItems, this.player, container, inventorySlot, this.forced);
-		// Execute unequipped commands.
-		for (const droppedItem of droppedItems)
-			droppedItem.executeUnequippedCommands();
-		// Container is a weight puzzle.
-		if (container instanceof Puzzle && container.type === "weight") {
-			const weight = container.getContainedItemsWeight();
-			const attemptAction = new AttemptAction(this.getGame(), undefined, this.player, this.location, this.forced);
-			attemptAction.performAttempt(container, undefined, String(weight), "drop", "");
-		}
-		// Container is a container puzzle.
-		else if (container instanceof Puzzle && container.type === "container") {
-			const containerItems = container.getContainedItems().filter(item => !isNaN(item.quantity));
-			const containerItemsString = getSortedItemsString(containerItems);
-			const attemptAction = new AttemptAction(this.getGame(), undefined, this.player, this.location, this.forced);
-			attemptAction.performAttempt(container, undefined, containerItemsString, "drop", "");
-		}
+            }
+        }
+        this.getGame().narrationHandler.narrateUndress(this, droppedItems, container, this.player);
+        this.getGame().logHandler.logUndress(droppedItems, this.player, container, inventorySlot, this.forced);
+        // Execute unequipped commands.
+        for (const droppedItem of droppedItems)
+            droppedItem.executeUnequippedCommands();
+        // Container is a weight puzzle.
+        if (container instanceof Puzzle && container.type === "weight") {
+            const weight = container.getContainedItemsWeight();
+            const attemptAction = new AttemptAction(this.getGame(), undefined, this.player, this.location, this.forced);
+            attemptAction.performAttempt(container, undefined, String(weight), "drop", "");
+        }
+        // Container is a container puzzle.
+        else if (container instanceof Puzzle && container.type === "container") {
+            const containerItems = container.getContainedItems().filter(item => !isNaN(item.quantity));
+            const containerItemsString = getSortedItemsString(containerItems);
+            const attemptAction = new AttemptAction(this.getGame(), undefined, this.player, this.location, this.forced);
+            attemptAction.performAttempt(container, undefined, containerItemsString, "drop", "");
+        }
         const slotPhrase = inventorySlot ? `${inventorySlot.id} of ` : ``;
         this.successMessage = `Successfully undressed ${this.player.name}, putting ${generateListString(droppedItems.map(item => item.getIdentifier()))} in ${slotPhrase}${container.getEntityID()}.`;
-	}
+    }
 }

--- a/Data/Actions/ViewAction.ts
+++ b/Data/Actions/ViewAction.ts
@@ -48,7 +48,7 @@ export default class ViewAction extends Action {
      * @param row
      * @param field - The name of a field belonging to the given entity to view. Optional.
      */
-    async performView<T extends PersistentGameEntity>(entity: T, field?: EntityField<T>): Promise<void> {
+    performView<T extends PersistentGameEntity>(entity: T, field?: EntityField<T>): void {
         if (this.performed) return;
         super.perform();
         let entityType: PersistentGameEntityName;
@@ -58,67 +58,67 @@ export default class ViewAction extends Action {
         if (entity instanceof Room) {
             entityType = "Room";
             views = this.#getRoomView(entity, field as RoomField);
-            if (!field) interactables = await this.#getRoomInteractables(entity);
+            if (!field) interactables = this.#getRoomInteractables(entity);
         }
         if (entity instanceof Exit) {
             entityType = "Exit";
             views = this.#getExitView(entity, field as ExitField);
-            if (!field) interactables = await this.#getExitInteractables(entity);
+            if (!field) interactables = this.#getExitInteractables(entity);
         }
         if (entity instanceof Fixture) {
             entityType = "Fixture";
             views = this.#getFixtureView(entity, field as FixtureField);
-            if (!field) interactables = await this.#getFixtureInteractables(entity);
+            if (!field) interactables = this.#getFixtureInteractables(entity);
         }
         if (entity instanceof Prefab) {
             entityType = "Prefab";
             views = this.#getPrefabView(entity, field as PrefabField);
-            if (!field) interactables = await this.#getPrefabInteractables(entity);
+            if (!field) interactables = this.#getPrefabInteractables(entity);
         }
         if (entity instanceof Recipe) {
             entityType = "Recipe";
             views = this.#getRecipeView(entity, field as RecipeField);
-            if (!field) interactables = await this.#getRecipeInteractables(entity);
+            if (!field) interactables = this.#getRecipeInteractables(entity);
         }
         if (entity instanceof RoomItem) {
             entityType = "RoomItem";
             views = this.#getRoomItemView(entity, field as RoomItemField);
-            if (!field) interactables = await this.#getRoomItemInteractables(entity);
+            if (!field) interactables = this.#getRoomItemInteractables(entity);
         }
         if (entity instanceof Puzzle) {
             entityType = "Puzzle";
             views = this.#getPuzzleView(entity, field as PuzzleField);
-            if (!field) interactables = await this.#getPuzzleInteractables(entity);
+            if (!field) interactables = this.#getPuzzleInteractables(entity);
         }
         if (entity instanceof Event) {
             entityType = "Event";
             views = this.#getEventView(entity, field as EventField);
-            if (!field) interactables = await this.#getEventInteractables(entity);
+            if (!field) interactables = this.#getEventInteractables(entity);
         }
         if (entity instanceof Status) {
             entityType = "StatusEffect";
             views = this.#getStatusView(entity, field as StatusField);
-            if (!field) interactables = await this.#getStatusInteractables(entity);
+            if (!field) interactables = this.#getStatusInteractables(entity);
         }
         if (entity instanceof Player) {
             entityType = "Player";
             views = this.#getPlayerView(entity, field as PlayerField);
-            if (!field) interactables = await this.#getPlayerInteractables(entity);
+            if (!field) interactables = this.#getPlayerInteractables(entity);
         }
         if (entity instanceof InventoryItem) {
             entityType = "InventoryItem";
             views = this.#getInventoryItemView(entity, field as InventoryItemField);
-            if (!field) interactables = await this.#getInventoryItemInteractables(entity);
+            if (!field) interactables = this.#getInventoryItemInteractables(entity);
         }
         if (entity instanceof Gesture) {
             entityType = "Gesture";
             views = this.#getGestureView(entity, field as GestureField);
-            if (!field) interactables = await this.#getGestureInteractables(entity);
+            if (!field) interactables = this.#getGestureInteractables(entity);
         }
         if (entity instanceof Flag) {
             entityType = "Flag";
             views = this.#getFlagView(entity, field as FlagField);
-            if (!field) interactables = await this.#getFlagInteractables(entity);
+            if (!field) interactables = this.#getFlagInteractables(entity);
         }
         this.getGame().communicationHandler.sendEntityView(entityType, entity.row, views, interactables);
     }
@@ -220,18 +220,18 @@ export default class ViewAction extends Action {
      * Gets interactables for the given room.
      * @param entity - The entity to generate interactables for.
      */
-    async #getRoomInteractables(entity: Room): Promise<Interactable[]> {
+    #getRoomInteractables(entity: Room): Interactable[] {
         let interactables: Interactable[];
         const fields: RoomField[] = ["description"];
         let relatedEntities: PersistentGameEntity[] = [];
         entity.exits.forEach(exit => relatedEntities.push(exit));
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
         const containedEntityQueries = [
             entity.getFindActionDirectiveArgs("Fixtures"),
             entity.getFindActionDirectiveArgs("RoomItems"),
             entity.getFindActionDirectiveArgs("Puzzles")
         ];
-        interactables = interactables.concat(await this.#interactableManager.createFindActionInteractables(containedEntityQueries, this.user));
+        interactables = interactables.concat(this.#interactableManager.createFindActionInteractables(containedEntityQueries, this.user));
         return interactables;
     }
 
@@ -263,12 +263,12 @@ export default class ViewAction extends Action {
      * Gets interactables for the given exit.
      * @param entity - The entity to generate interactables for.
      */
-    async #getExitInteractables(entity: Exit): Promise<Interactable[]> {
+    #getExitInteractables(entity: Exit): Interactable[] {
         let interactables: Interactable[];
         const fields: ExitField[] = ["description"];
         let relatedEntities: PersistentGameEntity[] = [];
         relatedEntities.push(entity.dest);
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
         return interactables;
     }
 
@@ -301,16 +301,16 @@ export default class ViewAction extends Action {
      * Gets interactables for the given fixture.
      * @param entity - The entity to generate interactables for.
      */
-    async #getFixtureInteractables(entity: Fixture): Promise<Interactable[]> {
+    #getFixtureInteractables(entity: Fixture): Interactable[] {
         let interactables: Interactable[];
         const fields: FixtureField[] = ["description"];
         let relatedEntities: PersistentGameEntity[] = [];
         relatedEntities.push(entity.location);
         if (entity.childPuzzle) relatedEntities.push(entity.childPuzzle);
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
-        interactables = interactables.concat(await this.#interactableManager.getFindContainedItemsInteractables(entity, this.user));
-        interactables = interactables.concat(await this.#interactableManager.getInstantiateRoomItemInteractables([entity], this.user));
-        interactables = interactables.concat(await this.#interactableManager.getDestroyRoomItemInteractables([entity], this.user));
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = interactables.concat(this.#interactableManager.getFindContainedItemsInteractables(entity, this.user));
+        interactables = interactables.concat(this.#interactableManager.getInstantiateRoomItemInteractables([entity], this.user));
+        interactables = interactables.concat(this.#interactableManager.getDestroyRoomItemInteractables([entity], this.user));
         return interactables;
     }
 
@@ -350,7 +350,7 @@ export default class ViewAction extends Action {
      * Gets interactables for the given prefab.
      * @param entity - The entity to generate interactables for.
      */
-    async #getPrefabInteractables(entity: Prefab): Promise<Interactable[]> {
+    #getPrefabInteractables(entity: Prefab): Interactable[] {
         let interactables: Interactable[];
         const fields: PrefabField[] = ["description", "commandsString", "proceduralOptions"];
         if (entity.possibleNames.size > 1) fields.push("possibleNames");
@@ -359,7 +359,7 @@ export default class ViewAction extends Action {
         entity.effects.forEach(status => relatedEntities.push(status));
         entity.cures.forEach(status => relatedEntities.push(status));
         if (entity.nextStage) relatedEntities.push(entity.nextStage);
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
         return interactables;
     }
 
@@ -387,13 +387,13 @@ export default class ViewAction extends Action {
      * Gets interactables for the given recipe.
      * @param entity - The entity to generate interactables for.
      */
-    async #getRecipeInteractables(entity: Recipe): Promise<Interactable[]> {
+    #getRecipeInteractables(entity: Recipe): Interactable[] {
         let interactables: Interactable[];
         const fields: RecipeField[] = ["initiatedDescription", "completedDescription", "uncraftedDescription"];
         let relatedEntities: PersistentGameEntity[] = [];
         entity.ingredientsFlat.forEach(ingredient => relatedEntities.push(ingredient.prefab));
         entity.productsFlat.forEach(product => relatedEntities.push(product.prefab));
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
         return interactables;
     }
 
@@ -425,18 +425,18 @@ export default class ViewAction extends Action {
      * Gets interactables for the given room item.
      * @param entity - The entity to generate interactables for.
      */
-    async #getRoomItemInteractables(entity: RoomItem): Promise<Interactable[]> {
+    #getRoomItemInteractables(entity: RoomItem): Interactable[] {
         let interactables: Interactable[];
         const fields: RoomItemField[] = ["description", "proceduralSelections"];
         let relatedEntities: PersistentGameEntity[] = [];
         relatedEntities.push(entity.prefab);
         relatedEntities.push(entity.location);
         if (entity.container) relatedEntities.push(entity.container);
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
         if (entity.quantity !== 0) {
-            interactables = interactables.concat(await this.#interactableManager.getFindContainedItemsInteractables(entity, this.user));
-            interactables = interactables.concat(await this.#interactableManager.getInstantiateRoomItemInteractables([entity], this.user));
-            interactables = interactables.concat(await this.#interactableManager.getDestroyRoomItemInteractables([entity], this.user));
+            interactables = interactables.concat(this.#interactableManager.getFindContainedItemsInteractables(entity, this.user));
+            interactables = interactables.concat(this.#interactableManager.getInstantiateRoomItemInteractables([entity], this.user));
+            interactables = interactables.concat(this.#interactableManager.getDestroyRoomItemInteractables([entity], this.user));
         }
         return interactables;
     }
@@ -471,17 +471,17 @@ export default class ViewAction extends Action {
      * Gets interactables for the given puzzle.
      * @param entity - The entity to generate interactables for.
      */
-    async #getPuzzleInteractables(entity: Puzzle): Promise<Interactable[]> {
+    #getPuzzleInteractables(entity: Puzzle): Interactable[] {
         let interactables: Interactable[];
         const fields: PuzzleField[] = ["correctDescription", "alreadySolvedDescription", "unsolvedDescription", "incorrectDescription", "noMoreAttemptsDescription", "requirementsNotMetDescription", "commandSetsString"];
         let relatedEntities: PersistentGameEntity[] = [];
         relatedEntities.push(entity.location);
         if (entity.parentFixture) relatedEntities.push(entity.parentFixture);
         entity.requirements.forEach(requirement => relatedEntities.push(requirement));
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
-        interactables = interactables.concat(await this.#interactableManager.getFindContainedItemsInteractables(entity, this.user));
-        interactables = interactables.concat(await this.#interactableManager.getInstantiateRoomItemInteractables([entity], this.user));
-        interactables = interactables.concat(await this.#interactableManager.getDestroyRoomItemInteractables([entity], this.user));
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = interactables.concat(this.#interactableManager.getFindContainedItemsInteractables(entity, this.user));
+        interactables = interactables.concat(this.#interactableManager.getInstantiateRoomItemInteractables([entity], this.user));
+        interactables = interactables.concat(this.#interactableManager.getDestroyRoomItemInteractables([entity], this.user));
         return interactables;
     }
 
@@ -512,13 +512,13 @@ export default class ViewAction extends Action {
      * Gets interactables for the given event.
      * @param entity - The entity to generate interactables for.
      */
-    async #getEventInteractables(entity: Event): Promise<Interactable[]> {
+    #getEventInteractables(entity: Event): Interactable[] {
         let interactables: Interactable[];
         const fields: EventField[] = ["triggeredNarration", "endedNarration", "commandsString"];
         let relatedEntities: PersistentGameEntity[] = [];
         entity.effects.forEach(effect => relatedEntities.push(effect));
         entity.refreshes.forEach(effect => relatedEntities.push(effect));
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
         return interactables;
     }
 
@@ -552,7 +552,7 @@ export default class ViewAction extends Action {
      * Gets interactables for the given status.
      * @param entity - The entity to generate interactables for.
      */
-    async #getStatusInteractables(entity: Status): Promise<Interactable[]> {
+    #getStatusInteractables(entity: Status): Interactable[] {
         let interactables: Interactable[];
         const fields: StatusField[] = ["inflictedDescription", "curedDescription"];
         let relatedEntities: PersistentGameEntity[] = [];
@@ -561,7 +561,7 @@ export default class ViewAction extends Action {
         if (entity.nextStage) relatedEntities.push(entity.nextStage);
         if (entity.duplicatedStatus) relatedEntities.push(entity.duplicatedStatus);
         if (entity.curedCondition) relatedEntities.push(entity.curedCondition);
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
         return interactables;
     }
 
@@ -598,7 +598,7 @@ export default class ViewAction extends Action {
      * Gets interactables for the given player.
      * @param entity - The entity to generate interactables for.
      */
-    async #getPlayerInteractables(entity: Player): Promise<Interactable[]> {
+    #getPlayerInteractables(entity: Player): Interactable[] {
         let interactables: Interactable[];
         const fields: PlayerField[] = ["description"];
         let relatedEntities: PersistentGameEntity[] = [];
@@ -606,7 +606,7 @@ export default class ViewAction extends Action {
             relatedEntities.push(entity.location);
             entity.status.forEach(status => relatedEntities.push(status));
         }
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
         return interactables;
     }
 
@@ -638,21 +638,21 @@ export default class ViewAction extends Action {
      * Gets interactables for the given inventory item.
      * @param entity - The entity to generate interactables for.
      */
-    async #getInventoryItemInteractables(entity: InventoryItem): Promise<Interactable[]> {
+    #getInventoryItemInteractables(entity: InventoryItem): Interactable[] {
         let interactables: Interactable[];
         const fields: InventoryItemField[] = ["description", "proceduralSelections"];
         let relatedEntities: PersistentGameEntity[] = [];
         relatedEntities.push(entity.player);
         if (entity.prefab) relatedEntities.push(entity.prefab);
         if (entity.container) relatedEntities.push(entity.container);
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
         if (entity.quantity !== 0) {
-            interactables = interactables.concat(await this.#interactableManager.getFindContainedItemsInteractables(entity, this.user));
+            interactables = interactables.concat(this.#interactableManager.getFindContainedItemsInteractables(entity, this.user));
             const isEquipped = entity.container === null && entity.prefab !== null;
             const isEmpty = entity.container === null && entity.prefab === null;
             const equipmentSlot = entity.player.inventory.get(entity.equipmentSlot);
-            interactables = interactables.concat(await this.#interactableManager.getInstantiateInventoryItemInteractables(entity.player, this.user, isEmpty ? [equipmentSlot] : [], isEquipped ? [] : [entity]));
-            interactables = interactables.concat(await this.#interactableManager.getDestroyInventoryItemInteractables(entity.player, this.user, isEquipped ? [entity] : [], isEmpty ? [] : [entity]));
+            interactables = interactables.concat(this.#interactableManager.getInstantiateInventoryItemInteractables(entity.player, this.user, isEmpty ? [equipmentSlot] : [], isEquipped ? [] : [entity]));
+            interactables = interactables.concat(this.#interactableManager.getDestroyInventoryItemInteractables(entity.player, this.user, isEquipped ? [entity] : [], isEmpty ? [] : [entity]));
         }
         return interactables;
     }
@@ -680,12 +680,12 @@ export default class ViewAction extends Action {
      * Gets interactables for the given gesture.
      * @param entity - The entity to generate interactables for.
      */
-    async #getGestureInteractables(entity: Gesture): Promise<Interactable[]> {
+    #getGestureInteractables(entity: Gesture): Interactable[] {
         let interactables: Interactable[];
         const fields: GestureField[] = ["narration"];
         let relatedEntities: PersistentGameEntity[] = [];
         entity.disabledStatuses.forEach(status => relatedEntities.push(status));
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
         return interactables;
     }
 
@@ -711,11 +711,11 @@ export default class ViewAction extends Action {
      * Gets interactables for the given flag.
      * @param entity - The entity to generate interactables for.
      */
-    async #getFlagInteractables(entity: Flag): Promise<Interactable[]> {
+    #getFlagInteractables(entity: Flag): Interactable[] {
         let interactables: Interactable[];
         const fields: FlagField[] = ["commandSetsString"];
         let relatedEntities: PersistentGameEntity[] = [];
-        interactables = await this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
+        interactables = this.#interactableManager.getViewInteractables(entity, fields, relatedEntities, this.user);
         return interactables;
     }
 }

--- a/Data/Actions/ViewPartyAction.ts
+++ b/Data/Actions/ViewPartyAction.ts
@@ -14,11 +14,11 @@ export default class ViewPartyAction extends Action {
 	/**
 	 * Performs a view party action.
 	 */
-	async performViewParty(): Promise<void> {
+	performViewParty(): void {
 		if (this.performed) return;
 		super.perform();
 		const partyString = this.player.viewParty(this.forced);
-		const interactables = await this.#getInteractables();
+		const interactables = this.#getInteractables();
 
 		if (this.forced)
 			this.getGame().communicationHandler.sendToCommandChannel(partyString, interactables);
@@ -26,7 +26,7 @@ export default class ViewPartyAction extends Action {
 			this.getGame().communicationHandler.sendMessageToPlayer(this.player, partyString, true, undefined, undefined, interactables);
 	}
 
-    async #getInteractables(): Promise<Interactable[]> {
+    #getInteractables(): Interactable[] {
         let interactables: Interactable[] = [];
         return interactables;
     }

--- a/Data/Description.ts
+++ b/Data/Description.ts
@@ -109,7 +109,7 @@ export default class Description extends GameConstruct {
     /**
      * Parses and sends the description to the given player with interactables.
      */
-    async parseAndSendTo(player: Player, container: GameEntity = this.getContainer()): Promise<void> {
+    parseAndSendTo(player: Player, container: GameEntity = this.getContainer()): void {
         const parsedDescription = this.parseFor(player, container);
         let potentialGameEntities: string[] = [];
         let inspectableEntities: Inspectable[] = [];
@@ -130,20 +130,20 @@ export default class Description extends GameConstruct {
             const exits: Exit[] = [];
             for (const potentialGameEntity of potentialGameEntities)
                 if (container.exits.has(potentialGameEntity)) exits.push(container.exits.get(potentialGameEntity));
-            interactables = interactables.concat(await this.getGame().clientContext.interactableManager.createQueueMoveActionInteractables(exits, player));
-            interactables = interactables.concat(await this.getGame().clientContext.interactableManager.createInspectActionInteractable(inspectableEntities, player));
+            interactables = interactables.concat(this.getGame().clientContext.interactableManager.createQueueMoveActionInteractables(exits, player));
+            interactables = interactables.concat(this.getGame().clientContext.interactableManager.createInspectActionInteractable(inspectableEntities, player));
             player.sendRoomDescription(container, parsedDescription, occupantsString, defaultDropFixtureString, interactables);
         }
         else {
             potentialGameEntities = potentialGameEntities.concat(Description.getPotentialGameEntities(parsedDescription));
             const selectableInteractableGameEntities = this.getGame().entityFinder.getSelectableInteractableGameEntities(potentialGameEntities, container, player);
             inspectableEntities = inspectableEntities.concat(selectableInteractableGameEntities[0]);
-            interactables = interactables.concat(await this.getGame().clientContext.interactableManager.createInspectActionInteractable(inspectableEntities, player));
+            interactables = interactables.concat(this.getGame().clientContext.interactableManager.createInspectActionInteractable(inspectableEntities, player));
             if (container instanceof Fixture || container instanceof RoomItem || container instanceof Puzzle) {
-                interactables = interactables.concat(await this.getGame().clientContext.interactableManager.getTakeInteractables(container, selectableInteractableGameEntities[1], player));
-                interactables = interactables.concat(await this.getGame().clientContext.interactableManager.getDropInteractables(container, player));
+                interactables = interactables.concat(this.getGame().clientContext.interactableManager.getTakeInteractables(container, selectableInteractableGameEntities[1], player));
+                interactables = interactables.concat(this.getGame().clientContext.interactableManager.getDropInteractables(container, player));
                 if (container instanceof Fixture) {
-                    interactables = interactables.concat(await this.getGame().clientContext.interactableManager.getActivateOrDeactivateInteractables(container, player));
+                    interactables = interactables.concat(this.getGame().clientContext.interactableManager.getActivateOrDeactivateInteractables(container, player));
                 }
             }
             player.sendDescription(parsedDescription, container, this.messageDisplayType ?? MessageDisplayType.PLAIN_TEXT, interactables);

--- a/Data/Fixture.ts
+++ b/Data/Fixture.ts
@@ -245,14 +245,14 @@ export default class Fixture extends RecipeProcessor implements PersistentGameEn
     }
 
     /**
-	 * Gets all of the items that should appear in the fixture's item list.
+     * Gets all of the items that should appear in the fixture's item list.
      *
-	 * @param itemListName - The name of the item list. Unused.
-	 * @param player - The player the description is being sent to. Unused.
-	 */
-	override getContainedItemsForItemList(itemListName?: string, player?: Player): RoomItem[] {
-		return this.getGame().entityFinder.getRoomItems(undefined, this.location.id, true, 'Fixture', this.name);
-	}
+     * @param itemListName - The name of the item list. Unused.
+     * @param player - The player the description is being sent to. Unused.
+     */
+    override getContainedItemsForItemList(itemListName?: string, player?: Player): RoomItem[] {
+        return this.getGame().entityFinder.getRoomItems(undefined, this.location.id, true, 'Fixture', this.name);
+    }
 
     /**
      * Returns true if this entity contains an item with the given identifier or prefab ID.
@@ -329,19 +329,19 @@ export default class Fixture extends RecipeProcessor implements PersistentGameEn
      * Starts the process timer when no recipe was found and the fixture is set to deactivate automatically.
      */
     #startProcessTimerForAutoDeactivateFixtureWithNoRecipe(): void {
-        this.#setProcessDuration(Duration.fromObject({minutes: 1}));
+        this.#setProcessDuration(Duration.fromObject({ minutes: 1 }));
         this.#whenProcessTimerExpires(() => {
-			this.#performDeactivate();
+            this.#performDeactivate();
         });
     }
 
-	/**
+    /**
      * Ends recipe processing. If `this.autoDeactivate` is true, deactivates the fixture. Otherwise, just clears the process.
      */
-	#endProcess(): void {
-		if (this.autoDeactivate) this.#performDeactivate();
+    #endProcess(): void {
+        if (this.autoDeactivate) this.#performDeactivate();
         else this._clearProcess();
-	}
+    }
 
     /**
      * Makes the fixture start processing recipes.
@@ -361,7 +361,7 @@ export default class Fixture extends RecipeProcessor implements PersistentGameEn
         this.#setProcessDuration();
         this.#whenProcessTimerExpires(() => {
             this.processRecipe(player);
-			this.#endProcess();
+            this.#endProcess();
         });
     }
 
@@ -389,7 +389,7 @@ export default class Fixture extends RecipeProcessor implements PersistentGameEn
             this.#setProcessDuration();
             this.#whenProcessTimerExpires(() => {
                 this.processRecipe();
-				this.#endProcess();
+                this.#endProcess();
             });
         }
     }
@@ -402,32 +402,32 @@ export default class Fixture extends RecipeProcessor implements PersistentGameEn
     private processRecipe(player?: Player): void {
         // Calculate how many times the fixture's ingredients satisfy the current recipe.
         this.process.satisfactoryProcessCount = this.process.recipe.getSatisfactoryProcessCount(this.process.ingredients);
-		if (this.process.satisfactoryProcessCount < 1) return;
+        if (this.process.satisfactoryProcessCount < 1) return;
         const variableValues = this.process.recipe.getIngredientVariableValues(this.process.ingredients);
         const proceduralSelections = combineProceduralSelections(this.process.ingredients);
         this.destroyIngredients(this.process.recipe, this.process.ingredients, this.process.satisfactoryProcessCount);
-		const instantiatedProducts = this.instantiateProducts<RoomItem>(this.process.recipe, this.process.satisfactoryProcessCount, variableValues, proceduralSelections, player);
+        const instantiatedProducts = this.instantiateProducts<RoomItem>(this.process.recipe, this.process.satisfactoryProcessCount, variableValues, proceduralSelections, player);
         this.#setProcessProducts(instantiatedProducts);
-		this.#sendRecipeCompletedDescription(player);
+        this.#sendRecipeCompletedDescription(player);
     }
 
-	/**
-	 * Instantiates a room item in this fixture.
+    /**
+     * Instantiates a room item in this fixture.
      *
-	 * @param prefab - The prefab to instantiate.
-	 * @param quantity - The quantity of the prefab to instantiate.
-	 * @param uses - The number of uses to instantiate the prefab with. Defaults to the prefab's number of uses.
-	 * @param proceduralSelections - The manually selected procedural possibilities.
-	 * @param container - The container to instantiate the prefab into. Defaults to the fixture itself.
-	 * @param inventorySlotId - The ID of the {@link InventorySlot|inventory slot} to instantiate the item in.
+     * @param prefab - The prefab to instantiate.
+     * @param quantity - The quantity of the prefab to instantiate.
+     * @param uses - The number of uses to instantiate the prefab with. Defaults to the prefab's number of uses.
+     * @param proceduralSelections - The manually selected procedural possibilities.
+     * @param container - The container to instantiate the prefab into. Defaults to the fixture itself.
+     * @param inventorySlotId - The ID of the {@link InventorySlot|inventory slot} to instantiate the item in.
      * @param player - The player who caused this instantiation, if applicable.
-	 * @returns The instantiated room item.
-	 */
-	protected override instantiate(prefab: Prefab, quantity: number, uses: number = prefab.uses, proceduralSelections: Map<string, string> = new Map(), container: RoomItemContainer = this.childPuzzle ?? this, inventorySlotId: string = "", player?: Player): RoomItem[] {
+     * @returns The instantiated room item.
+     */
+    protected override instantiate(prefab: Prefab, quantity: number, uses: number = prefab.uses, proceduralSelections: Map<string, string> = new Map(), container: RoomItemContainer = this.childPuzzle ?? this, inventorySlotId: string = "", player?: Player): RoomItem[] {
         const instantiatingPlayer = player && player.alive && player.location.id === this.location.id ? player : undefined;
-		const instantiateAction = new InstantiateRoomItemAction(this.getGame(), undefined, instantiatingPlayer, this.location, true);
-		return instantiateAction.performInstantiateRoomItem(prefab, container, inventorySlotId, quantity, proceduralSelections, uses);
-	}
+        const instantiateAction = new InstantiateRoomItemAction(this.getGame(), undefined, instantiatingPlayer, this.location, true);
+        return instantiateAction.performInstantiateRoomItem(prefab, container, inventorySlotId, quantity, proceduralSelections, uses);
+    }
 
     /**
      * Gets the actual ingredient item instance that was used as an ingredient in the currently processed recipe.
@@ -455,29 +455,29 @@ export default class Fixture extends RecipeProcessor implements PersistentGameEn
         return this.process.recipe?.productsFlat.find(product => product.prefab.id === prefabId)?.prefab;
     }
 
-	/**
-	 * If a player is given and they are still alive and in the same room as the fixture, sends them the processed recipe's completed description.
+    /**
+     * If a player is given and they are still alive and in the same room as the fixture, sends them the processed recipe's completed description.
      *
-	 * @param player - The player to send the completed description to.
-	 */
-	async #sendRecipeCompletedDescription(player: Player): Promise<void> {
-		if (player && player.alive && player.location.id === this.location.id) {
-			const completedDescription = this.process.recipe.completedDescription.parseFor(player, this);
-			const messageDisplayType = this.process.recipe.completedDescription.messageDisplayType ?? MessageDisplayType.STANDARD;
-			const interactables = await this.getGame().clientContext.interactableManager.createInspectActionInteractable([this], player);
-			player.sendDescription(completedDescription, this, messageDisplayType, interactables);
-		}
-	}
+     * @param player - The player to send the completed description to.
+     */
+    #sendRecipeCompletedDescription(player: Player): void {
+        if (player && player.alive && player.location.id === this.location.id) {
+            const completedDescription = this.process.recipe.completedDescription.parseFor(player, this);
+            const messageDisplayType = this.process.recipe.completedDescription.messageDisplayType ?? MessageDisplayType.STANDARD;
+            const interactables = this.getGame().clientContext.interactableManager.createInspectActionInteractable([this], player);
+            player.sendDescription(completedDescription, this, messageDisplayType, interactables);
+        }
+    }
 
-	/**
-	 * Creates a DeactivateAction and calls performDeactivate.
+    /**
+     * Creates a DeactivateAction and calls performDeactivate.
      *
-	 * @param player - The player who initiated the recipe, if any.
-	 */
-	#performDeactivate(player?: Player): void {
-		const deactivateAction = new DeactivateAction(this.getGame(), undefined, player, this.location, true);
+     * @param player - The player who initiated the recipe, if any.
+     */
+    #performDeactivate(player?: Player): void {
+        const deactivateAction = new DeactivateAction(this.getGame(), undefined, player, this.location, true);
         deactivateAction.performDeactivate(this, true);
-	}
+    }
 
     /**
      * Finds a recipe that can currently be processed by this fixture. The fixture must contain all of the ingredients for this recipe.

--- a/Test/Data/Actions/ActivateAction.test.ts
+++ b/Test/Data/Actions/ActivateAction.test.ts
@@ -35,16 +35,16 @@ describe('ActivateAction test', () => {
             fixtureActivateSpy = vi.spyOn(Fixture.prototype, 'activate');
         });
 
-        test('performed should be true', async () => {
+        test('performed should be true', () => {
             let action = new ActivateAction(game, message, player, location, false);
-            await action.performActivate(fixture, true);
+            action.performActivate(fixture, true);
             // @ts-ignore
             expect(action.performed).toBe(true);
         });
 
-        test('fixture activate should be called', async () => {
+        test('fixture activate should be called', () => {
             let action = new ActivateAction(game, message, player, location, false);
-            await action.performActivate(fixture, true);
+            action.performActivate(fixture, true);
             expect(fixtureActivateSpy).toHaveBeenCalled();
         });
     });

--- a/Test/Data/Actions/DropAction.test.ts
+++ b/Test/Data/Actions/DropAction.test.ts
@@ -19,7 +19,7 @@ describe("DropAction test", () => {
         await game.entityLoader.loadRoomItems(false);
     });
 
-    test("ported legacy test", async () => {
+    test("ported legacy test", () => {
         const kyra = game.entityFinder.getPlayer("Kyra");
         const vivian = game.entityFinder.getPlayer("Vivian");
         const kyraHand = game.entityFinder.getPlayerHandHoldingItem(kyra, "MUG OF COFFEE");
@@ -30,7 +30,7 @@ describe("DropAction test", () => {
         {
             const coffee = kyraHand.equippedItem;
             const dropAction = new DropAction(game, createMockMessage(), kyra, kyra.location, false);
-            await dropAction.performDrop(coffee, kyraHand, kyraFloor, null);
+            dropAction.performDrop(coffee, kyraHand, kyraFloor, null);
         }
 
         {
@@ -39,7 +39,7 @@ describe("DropAction test", () => {
             unequipAction.performUnequip(quiver,game.entityFinder.getPlayerEquipmentSlotWithEquippedItem(vivian, quiver.getIdentifier()),vivianHand);
             quiver = game.entityFinder.getInventoryItem("VIVIANS QUIVER");
             const dropAction = new DropAction(game, createMockMessage(), vivian, vivian.location, false);
-            await dropAction.performDrop(quiver, vivianHand, vivianFloor, null);
+            dropAction.performDrop(quiver, vivianHand, vivianFloor, null);
         }
 
         const coffee = game.entityFinder.getRoomItem("MUG OF COFFEE", kyra.location.id, "FIXTURE", kyraFloor.name);

--- a/Test/Data/Actions/StashAction.test.ts
+++ b/Test/Data/Actions/StashAction.test.ts
@@ -20,7 +20,7 @@ describe('StashAction test', () => {
         await game.entityLoader.loadRoomItems(false);
     });
 
-    test('ported legacy test', async () => {
+    test('ported legacy test', () => {
         const kyra = game.entityFinder.getLivingPlayer("Kyra");
         const hand = game.entityFinder.getPlayerFreeHand(kyra);
         const labCoat = game.entityFinder.getPlayerEquipmentSlotWithEquippedItem(kyra, "KYRAS LAB COAT").equippedItem;

--- a/Test/Data/Actions/TakeAction.test.ts
+++ b/Test/Data/Actions/TakeAction.test.ts
@@ -32,7 +32,7 @@ describe('TakeAction test', () => {
         await game.entityLoader.loadRoomItems(false);
     });
 
-    test('ported legacy test', async () => {
+    test('ported legacy test', () => {
         // grab common references
         const kyra = game.entityFinder.getPlayer("Kyra");
         const hand = game.entityFinder.getPlayerHandHoldingItem(kyra, "MUG OF COFFEE");
@@ -83,7 +83,7 @@ describe('TakeAction test', () => {
         {
             const coffee = hand.equippedItem;
             const dropAction = new DropAction(game, createMockMessage(), kyra, kyra.location, false);
-            await dropAction.performDrop(coffee, hand, floor, null);
+            dropAction.performDrop(coffee, hand, floor, null);
         }
 
         // step 1 validation
@@ -107,7 +107,7 @@ describe('TakeAction test', () => {
             unequipAction.performUnequip(jacket,game.entityFinder.getPlayerEquipmentSlotWithEquippedItem(kyra, jacket.getIdentifier()),hand);
             jacket = game.entityFinder.getInventoryItem("KYRAS LAB COAT", kyra.name);
             const dropAction = new DropAction(game, createMockMessage(), kyra, kyra.location, false);
-            await dropAction.performDrop(jacket, hand, floor, null);
+            dropAction.performDrop(jacket, hand, floor, null);
         }
 
         // step 2 validation
@@ -128,7 +128,7 @@ describe('TakeAction test', () => {
         {
             const coffee = game.entityFinder.getRoomItem("MUG OF COFFEE", kyra.location.id);
             const takeAction = new TakeAction(game, createMockMessage(), kyra, kyra.location, false);
-            await takeAction.performTake(coffee, hand, floor, null);
+            takeAction.performTake(coffee, hand, floor, null);
         }
 
         // step 3 validation
@@ -151,7 +151,7 @@ describe('TakeAction test', () => {
             const jacket = game.entityFinder.getRoomItem("KYRAS LAB COAT", kyra.location.id);
             const pocket = jacket.inventory.get("RIGHT POCKET")
             const dropAction = new DropAction(game, createMockMessage(), kyra, kyra.location, false);
-            await dropAction.performDrop(coffee, hand, jacket, pocket);
+            dropAction.performDrop(coffee, hand, jacket, pocket);
         }
 
         // step 4 validation
@@ -183,7 +183,7 @@ describe('TakeAction test', () => {
         {
             const jacket = game.entityFinder.getRoomItem("KYRAS LAB COAT", kyra.location.id);
             const takeAction = new TakeAction(game, createMockMessage(), kyra, kyra.location, false);
-            await takeAction.performTake(jacket, hand, floor, null);
+            takeAction.performTake(jacket, hand, floor, null);
         }
 
         // step 5 validation
@@ -217,7 +217,7 @@ describe('TakeAction test', () => {
             const drawer = game.entityFinder.getRoomItem("TOP DRAWER 9", kyra.location.id)
             const container = drawer.inventory.get("TOP DRAWER");
             const dropAction = new DropAction(game, createMockMessage(), kyra, kyra.location, false);
-            await dropAction.performDrop(jacket, hand, drawer, container);
+            dropAction.performDrop(jacket, hand, drawer, container);
         }
 
         // step 6 validation
@@ -261,7 +261,7 @@ describe('TakeAction test', () => {
             const drawer = game.entityFinder.getRoomItem("TOP DRAWER 9", kyra.location.id);
             const nightstand = game.entityFinder.getFixture("NIGHTSTAND", "suite-9")
             const takeAction = new TakeAction(game, createMockMessage(), kyra, kyra.location, false);
-            await takeAction.performTake(drawer, hand, nightstand, null);
+            takeAction.performTake(drawer, hand, nightstand, null);
         }
 
         // step 7 validation


### PR DESCRIPTION
This PR replaces the function to generate the customId for an ActionDirective with a synchronous function. This allows us to create Interactables synchronously, which means that many Actions whose perform functions were previously async can now be performed synchronously.

While this PR removes the `await` keyword from calls to those Actions, I've left the command files alone, to avoid complicating the work being done in #442.

This PR also moves the call to Player.move in StartMoveAction to its original place. It was moved as part of #450, but since ActionDirective customId generation can be done synchronously, the core problem that caused the LeadAction tests to fail has been resolved.