### PR TITLE
Further support for left-handedness

### DIFF
--- a/Data/Actions/UndressAction.ts
+++ b/Data/Actions/UndressAction.ts
@@ -28,23 +28,21 @@ export default class UndressAction extends Action {
         if (this.performed) return;
         super.perform();
         // First, drop the items in the player's hands.
-        const rightHand = this.player.inventory.get("RIGHT HAND");
-        const leftHand = this.player.inventory.get("LEFT HAND");
-        if (rightHand && rightHand.equippedItem !== null) {
-            const rightHandDropAction = new DropAction(this.getGame(), undefined, this.player, this.location, this.forced);
-            rightHandDropAction.performDrop(rightHand.equippedItem, rightHand, container, inventorySlot, true);
+        const hands = this.getGame().entityFinder.getPlayerHands(this.player);
+        for (const hand of hands) {
+            if (hand.equippedItem !== null) {
+                const dropAction = new DropAction(this.getGame(), undefined, this.player, this.location, this.forced);
+                dropAction.performDrop(hand.equippedItem, hand, container, inventorySlot, true);
+            }
         }
-        if (leftHand && leftHand.equippedItem !== null) {
-            const leftHandDropAction = new DropAction(this.getGame(), undefined, this.player, this.location, this.forced);
-            leftHandDropAction.performDrop(leftHand.equippedItem, leftHand, container, inventorySlot, true);
-        }
+        const dominantHand = hands[0];
         const droppedItems: InventoryItem[] = [];
         for (const equipmentSlot of this.player.inventory.values()) {
             if (equipmentSlot.equippedItem !== null && equipmentSlot.equippedItem.prefab.equippable) {
                 const droppedItem = equipmentSlot.equippedItem;
                 droppedItems.push(droppedItem);
-                this.player.unequip(equipmentSlot.equippedItem, equipmentSlot, rightHand);
-                this.player.drop(rightHand.equippedItem, rightHand, container, inventorySlot);
+                this.player.unequip(equipmentSlot.equippedItem, equipmentSlot, dominantHand);
+                this.player.drop(dominantHand.equippedItem, dominantHand, container, inventorySlot);
                 // Container is a drop puzzle.
                 if (container instanceof Puzzle && container.type === "drop") {
                     const attemptAction = new AttemptAction(this.getGame(), undefined, this.player, this.location, this.forced);

--- a/Data/Die.ts
+++ b/Data/Die.ts
@@ -97,12 +97,10 @@ export default class Die extends GameConstruct {
         if (attacker) {
             if (attacker.hasBehaviorAttribute("coin flipper")) {
                 let hasCoin = false;
-                const rightHand = attacker.inventory.get("RIGHT HAND");
-                const leftHand = attacker.inventory.get("LEFT HAND");
-                if (rightHand && rightHand.equippedItem !== null && rightHand.equippedItem.name.includes("COIN")
-                    || leftHand && leftHand.equippedItem !== null && leftHand.equippedItem.name.includes("COIN")) {
-                    hasCoin = true;
-                }
+                const hands = this.getGame().entityFinder.getPlayerHands(attacker);
+                for (const hand of hands)
+                    if (hand.equippedItem.name.includes("COIN"))
+                        hasCoin = true;
                 if (hasCoin) {
                     const coinModifier = this.doBaseRoll(0, 1);
                     if (coinModifier === 1) {

--- a/Data/Player.ts
+++ b/Data/Player.ts
@@ -1595,12 +1595,15 @@ export default class Player extends RecipeProcessor implements PersistentGameEnt
         let ingredient2 = oneDiscreet && recipe.ingredients[0].prefab.discreet ? recipe.ingredients[1] : recipe.ingredients[0];
         const proceduralSelections = item.proceduralSelections;
 
-        const rightHand = this.inventory.get("RIGHT HAND");
+        const hands = this.getGame().entityFinder.getPlayerHands(this);
+        const dominantHand = hands[0];
+        // this may very well be undefined... uncraft invocations should check for the existence of at least two hands
+        const auxiliaryHand = hands[1];
         const ingredient1Instance = itemManager.replaceInventoryItem(item, ingredient1.prefab);
         const instantiateAction = new InstantiateInventoryItemAction(this.getGame(), undefined, this, this.location, true);
         const ingredient2Instance = instantiateAction.performInstantiateInventoryItem(
             ingredient2.prefab,
-            rightHand.equippedItem === null ? "RIGHT HAND" : "LEFT HAND",
+            dominantHand.equippedItem === null ? dominantHand.id : auxiliaryHand.id,
             null,
             "",
             1,

--- a/Data/Player.ts
+++ b/Data/Player.ts
@@ -1597,7 +1597,11 @@ export default class Player extends RecipeProcessor implements PersistentGameEnt
 
         const hands = this.getGame().entityFinder.getPlayerHands(this);
         const dominantHand = hands[0];
-        // this may very well be undefined... uncraft invocations should check for the existence of at least two hands
+        /**
+         * @privateRemarks
+         * this may very well be undefined...
+         * uncraft invocations should check for the existence of at least two hands
+         */
         const auxiliaryHand = hands[1];
         const ingredient1Instance = itemManager.replaceInventoryItem(item, ingredient1.prefab);
         const instantiateAction = new InstantiateInventoryItemAction(this.getGame(), undefined, this, this.location, true);


### PR DESCRIPTION
Hello! This PR implements further support for left-handedness, replacing manual lookups for player hands in `Die.ts`, `Player.ts`, and `UndressAction.ts` with the corresponding invocation of the `GameEntityFinder.getPlayerHands()` method.

The uncraft commands still perform manual checks and lookups for the right and left hands, but I would like to leave those untouched so as to not complicate work on #442. If it is preferred that I also replace the manual lookups there, please simply let me know.
—❄️