### PR TITLE
TypeScript 7 support

### DIFF
--- a/Classes/GameNarrationHandler.ts
+++ b/Classes/GameNarrationHandler.ts
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2019 Alter Ego Contributors
+// SPDX-FileCopyrightText: 2026 LavCorps <lavcorps@protonmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -410,7 +411,7 @@ export default class GameNarrationHandler {
     narrateInspect(action: Action, target: Inspectable, player: Player) {
         let notification = "";
         let narration = "";
-        let messageType = MessageDisplayType.MINOR;
+        let messageType: MessageDisplayType = MessageDisplayType.MINOR;
         if (target instanceof Room) {
             notification = this.#game.notificationGenerator.generateInspectRoomNotification(player, true);
             narration = this.#game.notificationGenerator.generateInspectRoomNotification(player, false);
@@ -542,7 +543,7 @@ export default class GameNarrationHandler {
      */
     narrateInflict(action: Action, status: Status, player: Player) {
         let narration = "";
-        let messageType = MessageDisplayType.STANDARD;
+        let messageType: MessageDisplayType = MessageDisplayType.STANDARD;
         if (status.id === "asleep") narration = this.#game.notificationGenerator.generateFallAsleepNotification(player.displayName);
         else if (status.id === "blacked out") {
             narration = this.#game.notificationGenerator.generateBlackOutNotification(player.displayName);
@@ -564,7 +565,7 @@ export default class GameNarrationHandler {
      */
     narrateCure(action: Action, status: Status, player: Player, item?: InventoryItem) {
         let narration = "";
-        let messageType = MessageDisplayType.STANDARD;
+        let messageType: MessageDisplayType = MessageDisplayType.STANDARD;
         if (status.behaviorAttributes.has("concealed")) {
             const maskName = item ? item.name : "MASK";
             narration = this.#game.notificationGenerator.generateConcealedCuredNotification(maskName, player.displayName);
@@ -927,7 +928,7 @@ export default class GameNarrationHandler {
      * @param interactables - An array of interactables to send to the player alongside their notification. Optional.
      */
     narrateActivate(action: Action, fixture: Fixture, player?: Player, recipeInitiatedDescriptionSent: boolean = false, customNarration: string = "", interactables: Interactable[] = []) {
-        let messageType = MessageDisplayType.STANDARD;
+        let messageType: MessageDisplayType = MessageDisplayType.STANDARD;
         const fixturePhrase = fixture.getContainingPhrase();
         let notification = customNarration;
         let narration = customNarration;

--- a/Modules/enums.ts
+++ b/Modules/enums.ts
@@ -1,28 +1,30 @@
 // SPDX-FileCopyrightText: 2019 Alter Ego Contributors
+// SPDX-FileCopyrightText: 2026 LavCorps <lavcorps@protonmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-/** @enum {number} */
 export const MessageDisplayType = {
     STANDARD: 0,
-	WARNING: 1,
+    WARNING: 1,
     ALERT: 2,
     MINOR: 3,
     PLAYER: 4,
     MONOLOG: 5,
     PLAIN_TEXT: 6
-};
+} as const;
 
-/** @enum {number} */
+export type MessageDisplayType = typeof MessageDisplayType[keyof typeof MessageDisplayType];
+
 export const InteractableType = {
     BUTTON: 0,
     STRING_SELECT_MENU: 1,
     STRING_SELECT_MENU_OPTION: 2,
     MODAL: 3,
     TEXT_INPUT: 4
-};
+} as const;
 
-/** @enum {number} */
+export type InteractableType = valueof<typeof InteractableType>
+
 export const ActionPriority = {
     VIEW_FIELD: 1,
     VIEW: 2,
@@ -46,11 +48,14 @@ export const ActionPriority = {
     DROP: 40,
     ACTIVATE: 45,
     DEACTIVATE: 46
-};
+} as const;
 
-/** @enum {number} */
+export type ActionPriority = valueof<typeof ActionPriority>
+
 export const WhisperType = {
     STANDALONE: 0,
     HIDING_SPOT: 1,
     PARTY: 2
-};
+} as const;
+
+export type WhisperType = valueof<typeof WhisperType>

--- a/Modules/parser.ts
+++ b/Modules/parser.ts
@@ -1,9 +1,14 @@
+// SPDX-FileCopyrightText: 2019 Alter Ego Contributors
+// SPDX-FileCopyrightText: 2026 LavCorps <lavcorps@protonmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import CollatedItem from '../Data/CollatedItem.ts';
 import Description from '../Data/Description.ts';
 import ItemContainer from '../Data/ItemContainer.ts';
 import Player from '../Data/Player.ts';
-import { MessageDisplayType } from './enums.js';
+import { MessageDisplayType } from './enums.ts';
 import { default as evaluateScript } from './scriptParser.js';
 import { capitalizeFirstLetter, clamp, lowercaseFirstLetter } from './helpers.ts';
 import type GameEntity from '../Data/GameEntity.ts';

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2019 Alter Ego Contributors
+// SPDX-FileCopyrightText: 2026 LavCorps <lavcorps@protonmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -21,6 +22,9 @@ import type Moderator from "./Data/Moderator.ts";
 export { };
 
 declare global {
+    /** Utility type that indicates that something is to be a value of T. Used for enums. */
+    type valueof<T> = T[keyof T];
+
     /**
      * Represents a user of the bot in a game context.
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@typescript/native-preview": "^7.0.0-dev.20260705.1",
         "@xmldom/xmldom": "^0.8.11",
         "acorn": "^8.15.0",
         "date-fns": "^4.1.0",
@@ -22,9 +23,9 @@
         "@tsconfig/node24": "^24.0.4",
         "@types/luxon": "^3.7.1",
         "@types/node": "24.10.1",
-        "@vitest/coverage-v8": "^4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
         "typescript": "5.9.3",
-        "vitest": "^4.1.9"
+        "vitest": "4.1.9"
       },
       "engines": {
         "node": ">=24.14.1"
@@ -727,6 +728,139 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20260705.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260705.1.tgz",
+      "integrity": "sha512-mXc3tDkRCe8UinMcl5yqUfLAP5Vk5MFuZNNaNsrwRehu1d+lnL+Zu+K7g6kSMOV8NOY9bn9tGFN4/cqhlK4VwA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260705.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260705.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260705.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260705.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260705.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260705.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260705.1"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20260705.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260705.1.tgz",
+      "integrity": "sha512-OemjoGm+5nLCaUyL0zwWcSDhyQYQnO6/DcOidm2EzOqK7dYXgaCerDFUAz6iOGjOFtTAQFU50CV+ZbtUxodk9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20260705.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260705.1.tgz",
+      "integrity": "sha512-jYEsBtcVOin3ARa2xAkwM21KOlmr9s3FGxcY28gESigXPJOGooRaxZlJ45tFM3TczCMEGmML88XCXuQaH2z1kw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20260705.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260705.1.tgz",
+      "integrity": "sha512-abTOyfyx5SW5szf1YeZf5K9vUWEE7nbbqUUthl8OgRrFrJzlZnDIRf/FV0h6QGqQIN7XTf8lgKjdFe4piNFLww==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20260705.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260705.1.tgz",
+      "integrity": "sha512-kmWaZkuqb5RGTHt4AFIdPJ53/wO8vuZbmjSizNFNpvx1owYgQ8QZNu51zKfLQZbMs2FR7NAzVuQT14mhBaQW5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20260705.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260705.1.tgz",
+      "integrity": "sha512-oNA9I3MFLqdFVbwolnsFObjrQ1AsBXc4WXPcNyKcoaauAmFTwjxOBPKtiaqFKj4j4Abum7KvjVj0fgBaO5gRPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20260705.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260705.1.tgz",
+      "integrity": "sha512-K6hTgnqAEBbrIGH6feXM//FHbk0ilSAQDpLct+3IHfd+tg2sKop5lK2rTZkl/ptHM7Vlh0CF77m0RL73an+oAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20260705.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260705.1.tgz",
+      "integrity": "sha512-gAwPJgfQWtJnZlMrJ8NCA+vdI42N+XLev+jqZnpcMqt+Jd2zMtoNpppHB0I6URMVys+R2WpMiOOSlHcnvOMyTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "types": "dist/bot.d.ts",
   "dependencies": {
+    "@typescript/native-preview": "^7.0.0-dev.20260705.1",
     "@xmldom/xmldom": "^0.8.11",
     "acorn": "^8.15.0",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
Hello! This PR introduces preliminary support for TypeScript 7, notably introducing the `tsgo` preview to `package.json`, and migrating the old JavaScript JSDoc enums to a better supported enum style for TypeScript 7. Until the 7.x release on the main TypeScript package is old enough to satisfy project minimum age requirements, `npx tsgo` must be used in place of `npx tsc`.
—❄️