### PR TITLE
Do not collect test coverage by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         run: npm ci
 
       - name: Run tests with Vitest
-        run: npm test -- --coverage
+        run: npm run test:coverage
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v7

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
         globals: true,
         coverage: {
             provider: "v8",
-            enabled: true,
+            enabled: false,
             reportOnFailure: true,
             include: ["Classes/*.{js,ts}", "Commands/*.{js,ts}", "Data/*.{js,ts}", "Data/Actions/*.{js,ts}", "Modules/*.{js,ts}"],
         },


### PR DESCRIPTION
Hello! This PR tweaks the Vitest configuration to not collect coverage data by default, when run with `npm test`. This does not impact `npm run test:coverage`, and will not impact the coverage information as gathered by GitHub Actions. This is part one of two of the Natural Language Parser branch backports to `dev-2.1`.
—❄️