### PR TITLE
Constructor generic

### DIFF
--- a/Classes/ActionDirective.ts
+++ b/Classes/ActionDirective.ts
@@ -16,7 +16,7 @@ export default class ActionDirective<T extends Action = Action> {
     /**
      * The action this directive should create.
      */
-    readonly action: { new(...args: any[]): T };
+    readonly action: Constructor<T>;
     /**
      * The player the action should be constructed with by default.
      */
@@ -39,7 +39,7 @@ export default class ActionDirective<T extends Action = Action> {
      * @throws {TypeError} If the provided action is not a subclass of Action.
      */
     constructor(action: T, player: Player, args: any[], user: User) {
-        this.action = action.constructor as { new(...args: any[]): T };
+        this.action = action.constructor as Constructor<T>;
         this.#player = player;
         this.#args = args;
         this.customId = this.#generateCustomId(user);

--- a/Classes/ClientInteractableManager.ts
+++ b/Classes/ClientInteractableManager.ts
@@ -194,7 +194,7 @@ export default class ClientInteractableManager {
      * @param player - The player this action directive is being created for.
      * @param user - The user this action directive is being created for. This is used to generate a unique custom ID for the directive, preventing conflicts with directives created for other users with the same action and arguments.
      */
-    #createActionDirective<T extends Action>(actionClass: { new(...args: any[]): T }, args: any[], player: Player, user: User): ActionDirective<T> {
+    #createActionDirective<T extends Action>(actionClass: Constructor<T>, args: any[], player: Player, user: User): ActionDirective<T> {
         return new ActionDirective(actionClass.prototype, player, args, user);
     }
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -261,4 +261,7 @@ declare global {
 		getOwnPropertyDescriptor: (targetObject: Node, propKey: string | symbol) => TypedPropertyDescriptor<any>;
 		getPrototypeOf: (targetObject: Node) => object;
 	};
+
+	/** Convenience alias for the constructor of T. */
+    type Constructor<T extends any> = { new(...args: any[]): T }
 }


### PR DESCRIPTION
Hello! This PR introduces the Constructor generic to global types, representing the Constructor (with `...any[]` args) of any given type. This aids in typing the Constructors of objects for use in ActionDirectives right now, and is used to similar effect in the Natural Language Parser branch. This is part two of two of the Natural Language Parser branch backports to `dev-2.1`.
—❄️